### PR TITLE
Add a shim to znc

### DIFF
--- a/znc/Dockerfile
+++ b/znc/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     libperl-dev \
     pkg-config \
     curl \
+    sudo \
     --no-install-recommends
 
 # get the source
@@ -15,7 +16,21 @@ RUN curl -sSL http://znc.in/releases/znc-latest.tar.gz | tar -v -C /znc-tmp -xz
 RUN mv /znc-tmp/znc* /znc; rm -rf /znc-tmp
 
 # install it
-RUN cd /znc; ./configure; make; make install
+RUN cd /znc; ./configure; make -j8; make install
+RUN rm -rf /znc
+RUN mkdir /znc
+ADD znc-shim /usr/local/bin/znc-shim
+
+RUN adduser \
+    --system \
+    --home=/znc \
+    --shell=/bin/sh \
+    --no-create-home \
+    --group \
+    znc
+
+WORKDIR /znc
+ENTRYPOINT ["/usr/local/bin/znc-shim"]
 
 # make basic config
 # RUN znc --makeconf

--- a/znc/znc-shim
+++ b/znc/znc-shim
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+ZNC_DIR="/znc"
+ZNC_OWNER=$(stat -c "%U" ${ZNC_DIR})
+
+if [ "${ZNC_OWNER}" != "znc" ]; then
+    chown -R znc:znc ${ZNC_DIR}
+fi
+
+exec sudo -u znc "$@"


### PR DESCRIPTION
 This serves to do two things:

  1) chown /znc to znc:znc, which is really handy if the znc
     user inside the docker container has a new uid, because the
     files are stored on the host filesystem.
  2) to drop privs to the znc user, to reduce the attack surface.
