### PR TITLE
CMD => ENTRYPOINT

### DIFF
--- a/keepass2/Dockerfile
+++ b/keepass2/Dockerfile
@@ -28,4 +28,4 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-CMD ["/usr/bin/keepass2"]
+ENTRYPOINT ["/usr/bin/keepass2"]


### PR DESCRIPTION
Use ENTRYPOINT instead of CMD to allow command line arguments to be handed over on execution