### PR TITLE
[WIP] vscode 1.7.1

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y \
 	libxi6 \
 	libxrandr2 \
 	libxrender1 \
+	libxss1 \
 	libxtst6 \
 	liblzma5 \
 	--no-install-recommends
@@ -49,7 +50,9 @@ ENV HOME /home/user
 RUN useradd --create-home --home-dir $HOME user \
 	&& chown -R user:user $HOME
 
-ENV CODE_VERSION 1.5.3-1474533365
+ENV CODE_VERSION 1.7.1-1478180561
+ENV CODE_COMMIT 02611b40b24c9df2726ad8b33f5ef5f67ac30b44
+
 # download the source
 RUN buildDeps=' \
 		ca-certificates \
@@ -61,7 +64,7 @@ RUN buildDeps=' \
 	&& curl -sL https://deb.nodesource.com/setup_6.x | bash - \
 	&& apt-get update && apt-get install -y nodejs --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -sSL "https://az764295.vo.msecnd.net/stable/5be4091987a98e3870d89d630eb87be6d9bafd27/code_${CODE_VERSION}_amd64.deb" -o /tmp/vs.deb \
+	&& curl -sSL "https://az764295.vo.msecnd.net/stable/${CODE_COMMIT}/code_${CODE_VERSION}_amd64.deb" -o /tmp/vs.deb \
 	&& dpkg -i /tmp/vs.deb \
 	&& rm -rf /tmp/vs.deb \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/vscode/start.sh
+++ b/vscode/start.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-su user -c /usr/src/VSCode-linux-x64/code
+su user -c /usr/bin/code
+sleep infinity


### PR DESCRIPTION
So I updated vscode to 1.7.1.

Unfortunately ```/usr/local/bin/start.sh``` exits with 0 and launches vscode in a new process, causing the container to exit as well. Adding ```sleep infinity```seems to fix it for me.

There may be a better way to address this?