### PR TITLE
Update slack usage & allow command line arguments for keepass2 and slack

### DIFF
--- a/keepass2/Dockerfile
+++ b/keepass2/Dockerfile
@@ -9,7 +9,7 @@
 #		-v /home/$USER/DB.kdbx:/root/DB.kdbx \
 #		-v /tmp/.X11-unix:/tmp/.X11-unix \
 #		-e DISPLAY=$DISPLAY \
-#		keepass2
+#		keepass2 "$@"
 #
 # ISSUES:
 #	# 'Gtk: cannot open display: :0'

--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -4,10 +4,15 @@
 #	-v /etc/localtime:/etc/localtime:ro \
 #	-v /tmp/.X11-unix:/tmp/.X11-unix \
 #	-e DISPLAY=unix$DISPLAY \
-#	--device /dev/snd:/dev/snd \
-#	--device /dev/dri:/dev/dri \
+#	--device /dev/snd \
+#	--device /dev/dri \
+#	--device /dev/video0 \
+#	--group-add audio \
+#	--group-add video \
+#	-v "${HOME}/.slack:/root/.config/Slack" \
+#	--ipc="host" \
 #	--name slack \
-#	jess/slack
+#	jess/slack "$@"
 
 FROM debian:stretch
 MAINTAINER Jessie Frazelle <jess@linux.com>


### PR DESCRIPTION
Update the slack usage in the usage header to avoid crashes in some cases.

Allow command line arguments for keepass2 & slack.