### PR TITLE
tor browser alpha, hardened

### DIFF
--- a/tor-browser/alpha/Dockerfile
+++ b/tor-browser/alpha/Dockerfile
@@ -28,7 +28,7 @@ RUN useradd --create-home --home-dir $HOME user \
 
 ENV LANG C.UTF-8
 
-ENV TOR_VERSION 6.5a4
+ENV TOR_VERSION 6.5a5
 ENV TOR_FINGERPRINT 0x4E2C6E8793298290
 
 # download tor and check signature

--- a/tor-browser/hardened/Dockerfile
+++ b/tor-browser/hardened/Dockerfile
@@ -28,7 +28,7 @@ RUN useradd --create-home --home-dir $HOME user \
 
 ENV LANG C.UTF-8
 
-ENV TOR_VERSION 6.5a4-hardened
+ENV TOR_VERSION 6.5a5-hardened
 ENV TOR_FINGERPRINT 0x4E2C6E8793298290
 
 # download tor and check signature


### PR DESCRIPTION
I might also fix these god forsaken ```gpg: WARNING: unsafe ownership on homedir '/home/user/.gnupg'``` warnings at some point in the future, even though it's completely unnecessary. 