### PR TITLE
remove brace expansion

### DIFF
--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -23,7 +23,10 @@ MAINTAINER Jessie Frazelle <jess@linux.com>
 
 RUN apk --no-cache add \
 	transmission-daemon \
-	&& mkdir -p /transmission/{download,watch,incomplete,config} \
+	&& mkdir -p /transmission/download \
+		/transmission/watch \
+		/transmission/incomplete \
+		/transmission/config \
 	&& chmod 1777 /transmission
 
 ENV TRANSMISSION_HOME /transmission/config


### PR DESCRIPTION
Brace expansion doesn't work here because of the RUN command. This results in these directories not being created. Transmission still functions without them, but it wasn't what I expected to happen. 

[https://stackoverflow.com/questions/40164660/bash-brace-expansion-not-working-on-dockerfile-run-command](https://stackoverflow.com/questions/40164660/bash-brace-expansion-not-working-on-dockerfile-run-command)
