### PR TITLE
Bring Chromium container in line with Chrome

### DIFF
--- a/chrome/beta/Dockerfile
+++ b/chrome/beta/Dockerfile
@@ -15,7 +15,7 @@
 #	jess/chrome:beta
 #
 # You will want the custom seccomp profile:
-# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -o ~/chrome.json
+# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
 
 # Base docker image
 FROM debian:sid

--- a/chrome/beta/Dockerfile
+++ b/chrome/beta/Dockerfile
@@ -8,7 +8,7 @@
 #	-e DISPLAY=unix$DISPLAY \
 #	-v $HOME/Downloads:/home/chrome/Downloads \
 #	-v $HOME/.config/google-chrome/:/data \ # if you want to save state
-#	--security-opt seccomp=/etc/docker/seccomp/chrome.json
+#	--security-opt seccomp=$HOME/chrome.json \
 #	--device /dev/snd \ # so we have sound
 #	-v /dev/shm:/dev/shm \
 #	--name chrome \

--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -8,7 +8,7 @@
 #	-e DISPLAY=unix$DISPLAY \
 #	-v $HOME/Downloads:/home/chrome/Downloads \
 #	-v $HOME/.config/google-chrome/:/data \ # if you want to save state
-#	--security-opt seccomp=/etc/docker/seccomp/chrome.json
+#	--security-opt seccomp=$HOME/chrome.json \
 #	--device /dev/snd \ # so we have sound
 #	-v /dev/shm:/dev/shm \
 #	--name chrome \

--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -15,7 +15,7 @@
 #	jess/chrome
 #
 # You will want the custom seccomp profile:
-# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -o ~/chrome.json
+# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
 
 # Base docker image
 FROM debian:sid

--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
       libv4l-0 \
       fonts-symbola \
       --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /etc/chromium.d/ \
     && /bin/echo -e 'export GOOGLE_API_KEY="AIzaSyCkfPOPZXDKNn8hhgu3JrA62wIgC93d44k"\nexport GOOGLE_DEFAULT_CLIENT_ID="811574891467.apps.googleusercontent.com"\nexport GOOGLE_DEFAULT_CLIENT_SECRET="kdloedMFGdGla2P1zacGjAQh"' > /etc/chromium.d/googleapikeys \
     && dpkg -i '/src/google-talkplugin_current_amd64.deb'

--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -1,23 +1,21 @@
-# DESCRIPTION:	  Create chromium container with its dependencies
-# AUTHOR:		  Jessie Frazelle <jess@linux.com>
-# COMMENTS:
-#	This file describes how to build a Chromium container with all
-#	dependencies installed. It uses native X11 unix socket.
-#	Tested on Debian Jessie
-# USAGE:
-#	# Download Chromium Dockerfile
-#	wget https://raw.githubusercontent.com/jessfraz/dockerfiles/master/chromium/Dockerfile
+# Run Chromium in a container
 #
-#	# Build chromium image
-#	docker build -t chromium .
+# docker run -it \
+#	--net host \ # may as well YOLO
+#	--cpuset-cpus 0 \ # control the cpu
+#	--memory 512mb \ # max memory it can use
+#	-v /tmp/.X11-unix:/tmp/.X11-unix \ # mount the X11 socket
+#	-e DISPLAY=unix$DISPLAY \
+#	-v $HOME/Downloads:/home/chromium/Downloads \
+#	-v $HOME/.config/chromium/:/data \ # if you want to save state
+#	--security-opt seccomp=$HOME/chrome.json \
+#	--device /dev/snd \ # so we have sound
+#	-v /dev/shm:/dev/shm \
+#	--name chromium \
+#	jess/chromium
 #
-#	# Run stateful data-on-host chromium. For ephemeral, remove -v /data/chromium:/data
-#	docker run -v /data/chromium:/data -v /tmp/.X11-unix:/tmp/.X11-unix \
-#		-e DISPLAY=unix$DISPLAY chromium
-
-#	# To run stateful dockerized data containers
-#	docker run --volumes-from chromium-data -v /tmp/.X11-unix:/tmp/.X11-unix \
-#		-e DISPLAY=unix$DISPLAY chromium
+# You will want the custom seccomp profile:
+# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
 
 # Base docker image
 FROM debian:stretch

--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -26,26 +26,24 @@ MAINTAINER Jessie Frazelle <jess@linux.com>
 ADD https://dl.google.com/linux/direct/google-talkplugin_current_amd64.deb /src/google-talkplugin_current_amd64.deb
 
 # Install Chromium
-RUN echo 'deb http://httpredir.debian.org/debian testing main' >> /etc/apt/sources.list && \
-	apt-get update && apt-get install -y \
-	chromium \
-	chromium-l10n \
-	fonts-liberation \
-	fonts-roboto \
-	hicolor-icon-theme \
-	libcanberra-gtk-module \
-	libexif-dev \
-	libgl1-mesa-dri \
-	libgl1-mesa-glx \
-	libpango1.0-0 \
-	libv4l-0 \
-	-t testing \
-	fonts-symbola \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& mkdir -p /etc/chromium.d/ \
-	&& /bin/echo -e 'export GOOGLE_API_KEY="AIzaSyCkfPOPZXDKNn8hhgu3JrA62wIgC93d44k"\nexport GOOGLE_DEFAULT_CLIENT_ID="811574891467.apps.googleusercontent.com"\nexport GOOGLE_DEFAULT_CLIENT_SECRET="kdloedMFGdGla2P1zacGjAQh"' > /etc/chromium.d/googleapikeys \
-	&& dpkg -i '/src/google-talkplugin_current_amd64.deb'
+RUN apt-get update && apt-get install -y \
+      chromium \
+      chromium-l10n \
+      fonts-liberation \
+      fonts-roboto \
+      hicolor-icon-theme \
+      libcanberra-gtk-module \
+      libexif-dev \
+      libgl1-mesa-dri \
+      libgl1-mesa-glx \
+      libpango1.0-0 \
+      libv4l-0 \
+      fonts-symbola \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+    && mkdir -p /etc/chromium.d/ \
+    && /bin/echo -e 'export GOOGLE_API_KEY="AIzaSyCkfPOPZXDKNn8hhgu3JrA62wIgC93d44k"\nexport GOOGLE_DEFAULT_CLIENT_ID="811574891467.apps.googleusercontent.com"\nexport GOOGLE_DEFAULT_CLIENT_SECRET="kdloedMFGdGla2P1zacGjAQh"' > /etc/chromium.d/googleapikeys \
+    && dpkg -i '/src/google-talkplugin_current_amd64.deb'
 
 ENTRYPOINT [ "/usr/bin/chromium" ]
 CMD [ "--user-data-dir=/data" ]

--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -45,5 +45,12 @@ RUN apt-get update && apt-get install -y \
     && /bin/echo -e 'export GOOGLE_API_KEY="AIzaSyCkfPOPZXDKNn8hhgu3JrA62wIgC93d44k"\nexport GOOGLE_DEFAULT_CLIENT_ID="811574891467.apps.googleusercontent.com"\nexport GOOGLE_DEFAULT_CLIENT_SECRET="kdloedMFGdGla2P1zacGjAQh"' > /etc/chromium.d/googleapikeys \
     && dpkg -i '/src/google-talkplugin_current_amd64.deb'
 
+# Add chromium user
+RUN groupadd -r chromium && useradd -r -g chromium -G audio,video chromium \
+    && mkdir -p /home/chromium/Downloads && chown -R chromium:chromium /home/chromium
+
+# Run as non privileged user
+USER chromium
+
 ENTRYPOINT [ "/usr/bin/chromium" ]
 CMD [ "--user-data-dir=/data" ]


### PR DESCRIPTION
I noticed some nice work recently to get the Chrome container to work as an unprivileged user. This PR would bring the Chromium container in line with the Chrome one.

I generally cleaned up the Chromium container and removed some unnecessary steps. I'm guessing this was a Debian Jessie container in a previous life and the build commands weren't rewritten when it was rebased on Stretch.

I've tested this and it seems to work fine. Hopefully I'm not missing anything obvious.