### PR TITLE
Wireshark: Add CAP_NET_RAW and CAP_NET_ADMIN to /usr/bin/dumpcap

### DIFF
--- a/wireshark/Dockerfile
+++ b/wireshark/Dockerfile
@@ -24,7 +24,8 @@ ENV HOME /home/wireshark
 RUN useradd --create-home --home-dir $HOME wireshark \
 	&& chown -R wireshark:wireshark $HOME
 
-RUN setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
+RUN chown root:wireshark /usr/bin/dumpcap \
+	&& setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
 
 USER wireshark
 

--- a/wireshark/Dockerfile
+++ b/wireshark/Dockerfile
@@ -24,6 +24,8 @@ ENV HOME /home/wireshark
 RUN useradd --create-home --home-dir $HOME wireshark \
 	&& chown -R wireshark:wireshark $HOME
 
+RUN setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
+
 USER wireshark
 
 WORKDIR wireshark


### PR DESCRIPTION
Seemed to be unable to actually capture any packets from a network interface without the change to the Dockerfile and adding CAP_NET_RAW and CAP_NET_ADMIN to docker run command. If there is an easier way that I'm missing please feel free to close.
```
wireshark(){
	docker run -d \
		-v /etc/localtime:/etc/localtime:ro \
		-v /tmp/.X11-unix:/tmp/.X11-unix \
		-e DISPLAY=unix$DISPLAY \
		--net host \
		--cap-add NET_RAW \
		--cap-add NET_ADMIN \
		--name wireshark \
		wireshark
}
```
Wireshark docs for reference:
https://wiki.wireshark.org/CaptureSetup/CapturePrivileges