### PR TITLE
Fix Chromium uninstallable extensions bug

### DIFF
--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -18,15 +18,14 @@
 # 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
 
 # Base docker image
-FROM debian:stretch
+FROM ubuntu:16.04
 MAINTAINER Jessie Frazelle <jess@linux.com>
 
 ADD https://dl.google.com/linux/direct/google-talkplugin_current_amd64.deb /src/google-talkplugin_current_amd64.deb
 
 # Install Chromium
 RUN apt-get update && apt-get install -y \
-      chromium \
-      chromium-l10n \
+      chromium-browser \
       fonts-liberation \
       fonts-roboto \
       hicolor-icon-theme \
@@ -50,5 +49,5 @@ RUN groupadd -r chromium && useradd -r -g chromium -G audio,video chromium \
 # Run as non privileged user
 USER chromium
 
-ENTRYPOINT [ "/usr/bin/chromium" ]
+ENTRYPOINT [ "/usr/bin/chromium-browser" ]
 CMD [ "--user-data-dir=/data" ]


### PR DESCRIPTION
Not sure if you'll want to pull this in, but this provides a temporary fix for Debian bug [841401](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=841401) which is causing installation of extensions to fail in Debian Stretch's `chromium` package.

The bug report suggests that this should be fixed in `56.0.2924.76-5`, but that doesn't seem to be the case.

Temporarily rebasing the container on Ubuntu 16.04 fixes the problem and is easily reversible in future, since it doesn't involve a big change to the Dockerfile.