### PR TITLE
Rebase on "debian:stretch-slim"

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -1,24 +1,72 @@
-FROM debian:sid
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+FROM ubuntu:xenial
+LABEL github "https://github.com/mrorgues"
 
-RUN apt-get update && apt-get install -y \
-	dirmngr \
-	gnupg \
-	--no-install-recommends \
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21 \
-	&& echo "deb http://ppa.launchpad.net/mozillateam/firefox-next/ubuntu wily main" >> /etc/apt/sources.list.d/firefox.list \
-	&& apt-get update && apt-get install -y \
-	ca-certificates \
-	firefox \
-	hicolor-icon-theme \
-	libasound2 \
-	libgl1-mesa-dri \
-	libgl1-mesa-glx \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
 
-ENV LANG en-US
+#============================#
+# Information & Requirements #
+#============================#
+# *** Run firefox in a container ***
+#
+# docker run --rm -it \
+#   --net host \
+#   -v /tmp/.X11-unix:/tmp/.X11-unix \
+#   -e DISPLAY=unix$DISPLAY \
+#   --device /dev/dri \
+#   --device /dev/snd \
+#   -v /dev/shm:/dev/shm \
+#   -v /etc/machine-id:/etc/machine-id \
+#   --ipc="host" \
+#   --name firefox \
+#   mrorgues/firefox 
+#
+# *** Requirements ***
+#
+# Docker 1.9+ is required.
 
+
+#=================#
+# Basics & Locale #
+#=================#
 COPY local.conf /etc/fonts/local.conf
 
+ARG DEFAULT_LANGUAGE=fr_FR
+
+ENV LANG ${DEFAULT_LANGUAGE}".UTF-8"
+ENV LOCALE_GEN ${DEFAULT_LANGUAGE}".UTF-8 UTF-8"
+
+RUN apt-get update && \
+    apt-get install -y \
+    apt-transport-https \
+    dirmngr \
+    gnupg \
+    ca-certificates \
+    hicolor-icon-theme \
+    libasound2 \
+    libgl1-mesa-dri \
+    libgl1-mesa-glx \
+    libcanberra-gtk3-module \
+    locales \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo ${LOCALE_GEN} >> /etc/locale.gen && \
+    locale-gen && \
+    dpkg-reconfigure locales
+
+
+#=========#
+# Firefox #
+#=========#
+ARG FIREFOX_LOCALE=firefox-locale-fr
+
+RUN apt-get update && \
+    apt-get install -y \
+    firefox \
+    ${FIREFOX_LOCALE} \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+
+#=============#
+# Here we go! #
+#=============#
 ENTRYPOINT [ "/usr/bin/firefox" ]

--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -1,65 +1,81 @@
-# Run slack desktop app in a container
+FROM debian:stretch-slim
+LABEL github "https://github.com/mrorgues"
+
+
+#============================#
+# Information & Requirements #
+#============================#
+# *** Run slack desktop app in a container ***
 #
 # docker run --rm -it \
 #	-v /etc/localtime:/etc/localtime:ro \
 #	-v /tmp/.X11-unix:/tmp/.X11-unix \
 #	-e DISPLAY=unix$DISPLAY \
-#	--device /dev/snd \
 #	--device /dev/dri \
+#	--device /dev/snd \
 #	--device /dev/video0 \
 #	--group-add audio \
 #	--group-add video \
 #	-v "${HOME}/.slack:/root/.config/Slack" \
 #	--ipc="host" \
 #	--name slack \
-#	jess/slack "$@"
+#	mrorgues/slack 
 
-FROM debian:stretch
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-
+#=================#
+# Basics & Locale #
+#=================#
+ENV DEFAULT_LANGUAGE en_US
+ENV LANGUAGE ${DEFAULT_LANGUAGE}".UTF-8"
+ENV LC_ALL ${DEFAULT_LANGUAGE}".UTF-8"
+ENV LANG ${DEFAULT_LANGUAGE}".UTF-8"
+ENV LOCALE_GEN ${DEFAULT_LANGUAGE}".UTF-8 UTF-8"
 RUN apt-get update && apt-get install -y \
-	apt-transport-https \
-	ca-certificates \
-	gconf2 \
-	gconf-service \
-	gir1.2-gnomekeyring-1.0 \
-	gvfs-bin \
-	hunspell-en-us \
-	libappindicator1 \
-	libasound2 \
-	libgl1-mesa-dri \
-	libgl1-mesa-glx \
-	libgnome-keyring0 \
-	libgtk2.0-0 \
-	libnotify4 \
-	libnss3 \
-	libxss1 \
-	libxtst6 \
-	locales \
-	python \
-	xdg-utils \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+    apt-transport-https \
+    ca-certificates \
+    gconf2 \
+    gconf-service \
+    gir1.2-gnomekeyring-1.0 \
+    gvfs-bin \
+    hunspell-en-us \
+    libappindicator1 \
+    libasound2 \
+    libgl1-mesa-dri \
+    libgl1-mesa-glx \
+    libgnome-keyring0 \
+    libgtk2.0-0 \
+    libnotify4 \
+    libnss3 \
+    libxss1 \
+    libxtst6 \
+    locales \
+    python \
+    xdg-utils \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    touch /usr/share/locale/locale.alias && \
+    localedef -i ${DEFAULT_LANGUAGE} -c -f UTF-8 -A /usr/share/locale/locale.alias ${LC_ALL} && \
+    echo ${LOCALE_GEN} >> /etc/locale.gen && \
+    locale-gen && \
+    /usr/sbin/update-locale LANG=${LANG}
 
-RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
-	&& locale-gen en_US.utf8 \
-	&& /usr/sbin/update-locale LANG=en_US.UTF-8
 
+#=======#
+# Slack #
+#=======#
 ENV SLACK_VERSION 2.1.1
+ENV SLACK_DOWNLOAD_URL https://downloads.slack-edge.com/linux_releases/slack-desktop-${SLACK_VERSION}-amd64.deb
+RUN buildDeps='curl' && \
+    set -x && \
+    apt-get update && apt-get install -y $buildDeps --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -sSL "${SLACK_DOWNLOAD_URL}" > /tmp/slack-desktop.deb && \
+    dpkg -i /tmp/slack-desktop.deb && \
+    rm -rf /tmp/slack-desktop.deb && \
+    apt-get purge -y --auto-remove $buildDeps
 
-# download the deb and node
-RUN buildDeps=' \
-		curl \
-	' \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -sSL "https://downloads.slack-edge.com/linux_releases/slack-desktop-${SLACK_VERSION}-amd64.deb" > /tmp/slack-desktop.deb \
-	&& dpkg -i /tmp/slack-desktop.deb \
-	&& rm -rf /tmp/slack-desktop.deb \
-	&& apt-get purge -y --auto-remove $buildDeps
 
+#=============#
+# Here we go! #
+#=============#
 ENTRYPOINT ["/usr/lib/slack/slack"]


### PR DESCRIPTION
The image generated is much lighter (about 100 MB lighter)!

$ docker images | grep slack | awk '{printf "%-20s  %-10s\n",$1, $7}'
mrorgues/slack        471MB     
jess/slack                 570MB