### PR TITLE
Improve readme for tor-browser

### DIFF
--- a/tor-browser/stable/Dockerfile
+++ b/tor-browser/stable/Dockerfile
@@ -2,6 +2,8 @@
 #
 # docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
 #	-v /dev/snd:/dev/snd \
+#	-v /dev/shm:/dev/shm \
+#	-v /etc/machine-id:/etc/machine-id:ro \
 #	-e DISPLAY=unix$DISPLAY \
 #	jess/tor-browser
 #


### PR DESCRIPTION
The new tor-browser version crashes all the time / throws annoying errors if this stuff isn't mounted into the container.

Related: https://github.com/mozilla/geckodriver/issues/285