### PR TITLE
Get Firefox from an up-to-date repo

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 	gnupg \
 	--no-install-recommends \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21 \
-	&& echo "deb http://ppa.launchpad.net/mozillateam/firefox-next/ubuntu wily main" >> /etc/apt/sources.list.d/firefox.list \
+	&& echo "deb http://ppa.launchpad.net/mozillateam/firefox-next/ubuntu xenial main" >> /etc/apt/sources.list.d/firefox.list \
 	&& apt-get update && apt-get install -y \
 	ca-certificates \
 	firefox \


### PR DESCRIPTION
Since Ubuntu 15.10 isn't supported anymore the Firefox builds on there are quite old. I've changed them to get the builds for Xenial which means you should see a new PR from me in 2020 :stuck_out_tongue: 