### PR TITLE
fix tor-browser alpha

### DIFF
--- a/tor-browser/alpha/Dockerfile
+++ b/tor-browser/alpha/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
 	libasound2 \
 	libdbus-glib-1-2 \
 	libgtk2.0-0 \
+	libx11-xcb-dev \
 	libxrender1 \
 	libxt6 \
 	xz-utils \


### PR DESCRIPTION
Fixes
```
$ docker logs tor
Logging Tor Browser debug information to /dev/stdout
sed: couldn't open temporary file ../sed5QP46t: Permission denied
sed: couldn't open temporary file ../sediZDgXt: Permission denied
sed: couldn't open temporary file ../sedJGwXyt: Permission denied
/usr/local/bin/Browser/start-tor-browser: line 264: file: command not found
/usr/local/bin/Browser/start-tor-browser: line 266: [: 64: unary operator expected
XPCOMGlueLoad error for file /usr/local/bin/Browser/libxul.so:
libX11-xcb.so.1: cannot open shared object file: No such file or directory
Couldn't load XPCOM.
```