### PR TITLE
Install libpulse0 in spotify

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -25,6 +25,7 @@ RUN	apt-get update && apt-get install -y \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
 	libpangoxft-1.0-0 \
+	libpulse0 \
 	libssl1.0.0 \
 	libssl1.0.2 \
 	libxss1 \


### PR DESCRIPTION
Required to use PulseAudio. Same as here for the chrome image:  https://github.com/jessfraz/dockerfiles/commit/ff57ab29c945b21f5714666cf8234bc925a1a7fb