### PR TITLE
Allow the OpenVPN container to touch DNS

### DIFF
--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -2,5 +2,8 @@ FROM alpine:latest
 RUN apk --no-cache add \
 	openvpn
 
+RUN mkdir /usr/share/openvpn
+RUN cp /etc/openvpn/* /usr/share/openvpn/
+
 WORKDIR /etc/openvpn
 ENTRYPOINT ["openvpn"]

--- a/openvpn/README.md
+++ b/openvpn/README.md
@@ -24,6 +24,13 @@ If you **don't** need to specify a password, you can use `docker-compose run -d 
 If you OpenVPN configuration needs extra files (certificates etc) you can drop them in this directory too.
 
 
+## How to fix DNS
+To let OpenVPN change your resolv.conf file you need to add 2 scripts to your configuration to trigger the Alpine provided scripts.  
+```
+up /usr/share/openvpn/up.sh
+down /usr/share/openvpn/down.sh
+```
+
 ## Why?
 
 Because we're the containerati and we like when things are [neatly arranged in their boxes](https://twitter.com/zooeypeng/status/613053137050439681).

--- a/openvpn/docker-compose.yml
+++ b/openvpn/docker-compose.yml
@@ -2,6 +2,7 @@ vpn:
   build: .
   volumes:
     - .:/etc/openvpn
+    - /etc/resolv.conf:/etc/resolv.conf
   net: host
   devices:
     - /dev/net/tun:/dev/net/tun


### PR DESCRIPTION
I added a volume to the host's resolv.conf. Since the Alpine provided up and down scripts are overwritten by the config volume I placed a copy in `/usr/share/openvpn/`


As always feedback welcome!