### PR TITLE
Fix jess/vscode hanging as running indefinetely

### DIFF
--- a/vscode/start.sh
+++ b/vscode/start.sh
@@ -2,5 +2,4 @@
 set -e
 set -o pipefail
 
-su user -c /usr/bin/editor
-sleep infinity
+su user -p -c /usr/share/code/code


### PR DESCRIPTION
`sleep infinity` was keeping the process as running until being forced to stop with `docker container stop`

`/usr/bin/editor` is just a script that calls the editor (at another shell), using the right path (`/usr/share/code/code`) directly to call it fix this issue