### PR TITLE
Added: Using customized seccomp profile from the default one for Chrome/Chromium

### DIFF
--- a/chrome/beta/Dockerfile
+++ b/chrome/beta/Dockerfile
@@ -8,14 +8,16 @@
 #	-e DISPLAY=unix$DISPLAY \
 #	-v $HOME/Downloads:/home/chrome/Downloads \
 #	-v $HOME/.config/google-chrome/:/data \ # if you want to save state
-#	--security-opt seccomp=$HOME/chrome.json \
+#	--security-opt seccomp=$HOME/chrome_seccomp.json \
 #	--device /dev/snd \ # so we have sound
 #	-v /dev/shm:/dev/shm \
 #	--name chrome \
 #	jess/chrome:beta
 #
-# You will want the custom seccomp profile:
-# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
+# To generate the custom seccomp profile:
+#   curl https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json \
+#     | jq '.syscalls += [{"names": ["clone", "unshare", "setns"], "action": "SCMP_ACT_ALLOW"}]' \
+#     > ~/chrome_seccomp.json
 
 # Base docker image
 FROM debian:sid

--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -8,14 +8,16 @@
 #	-e DISPLAY=unix$DISPLAY \
 #	-v $HOME/Downloads:/home/chrome/Downloads \
 #	-v $HOME/.config/google-chrome/:/data \ # if you want to save state
-#	--security-opt seccomp=$HOME/chrome.json \
+#	--security-opt seccomp=$HOME/chrome_seccomp.json \
 #	--device /dev/snd \ # so we have sound
 #	-v /dev/shm:/dev/shm \
 #	--name chrome \
 #	jess/chrome
 #
-# You will want the custom seccomp profile:
-# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
+# To generate the custom seccomp profile:
+#   curl https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json \
+#     | jq '.syscalls += [{"names": ["clone", "unshare", "setns"], "action": "SCMP_ACT_ALLOW"}]' \
+#     > ~/chrome_seccomp.json
 
 # Base docker image
 FROM debian:sid

--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -8,14 +8,16 @@
 #	-e DISPLAY=unix$DISPLAY \
 #	-v $HOME/Downloads:/home/chromium/Downloads \
 #	-v $HOME/.config/chromium/:/data \ # if you want to save state
-#	--security-opt seccomp=$HOME/chrome.json \
+#	--security-opt seccomp=$HOME/chrome_seccomp.json \
 #	--device /dev/snd \ # so we have sound
 #	-v /dev/shm:/dev/shm \
 #	--name chromium \
 #	jess/chromium
 #
-# You will want the custom seccomp profile:
-# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
+# To generate the custom seccomp profile:
+#   curl https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json \
+#     | jq '.syscalls += [{"names": ["clone", "unshare", "setns"], "action": "SCMP_ACT_ALLOW"}]' \
+#     > ~/chrome_seccomp.json
 
 # Base docker image
 FROM debian:stretch


### PR DESCRIPTION
1. I reckon it might be somehow a better choice to minimize the change by appending a few rules to the default profile than fully re-writing it.

2. Unfortunately, I'm not yet 100% sure that with this updated profile Chrome/Chromium would work properly in every use case for everyone. But at least it's been working well for me so far. Please let me know if there's any sample case that breaks it.

3. In order to provide a minimal attack surface, this updated profile may be further enhanced by allowing only specific arguments that are actually used by Chrome/Chromium. This may be added in a future enhancement.