### PR TITLE
switch slack from debian:jessie to jessie-slim

### DIFF
--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -14,7 +14,7 @@
 #	--name slack \
 #	jess/slack "$@"
 
-FROM debian:jessie
+FROM debian:jessie-slim
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
Resolves #267 

This switches slack from debian:jessie to debian:jessie-slim, as suggested on #267.  Saves approximately 100mb and seems to work fine for me.
```
$ docker images|grep slack
slack        latest                ea2756b52176        12 minutes ago    362MB
jess/slack   latest                1d6dc561b3d3        5 hours ago       459MB
```