### PR TITLE
Update virtualbox to 5.2

### DIFF
--- a/virtualbox/Dockerfile
+++ b/virtualbox/Dockerfile
@@ -27,7 +27,7 @@
 #
 # then you can remove all the shit you copied
 # 	rm -rf /usr/share/virtualbox
-# 	rm vboxdrv
+# 	rm vboxdrv.sh
 #
 FROM debian:sid
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"

--- a/virtualbox/Dockerfile
+++ b/virtualbox/Dockerfile
@@ -43,7 +43,7 @@ RUN buildDeps=' \
 	&& curl -sSL https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - \
 	&& echo "deb http://download.virtualbox.org/virtualbox/debian stretch contrib" >> /etc/apt/sources.list.d/virtualbox.list \
 	&& apt-get update && apt-get install -y \
-	virtualbox-5.0 \
+	virtualbox-5.2 \
 	--no-install-recommends \
 	&& apt-get purge -y --auto-remove $buildDeps
 

--- a/virtualbox/Dockerfile
+++ b/virtualbox/Dockerfile
@@ -14,20 +14,19 @@
 # copy the files you need for the module from the container that
 # is currently running to your host
 #
-# first the script:
-# 	docker cp virtualbox:/usr/lib/virtualbox/vboxdrv.sh .
+# first the lib:
+# 	docker cp virtualbox:/usr/lib/virtualbox /usr/lib
 #
 # then the share
 # 	docker cp virtualbox:/usr/share/virtualbox /usr/share
 #
 # then run the script:
-# 	./vboxdrv.sh setup
+# 	/usr/lib/virtualbox/vboxdrv.sh setup
 #
 # it will recompile the module, you can then see it in lsmod
 #
 # then you can remove all the shit you copied
-# 	rm -rf /usr/share/virtualbox
-# 	rm vboxdrv.sh
+# 	rm -rf /usr/share/virtualbox /usr/lib/virtualbox
 #
 FROM debian:sid
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"


### PR DESCRIPTION
Simply update to latest version to be able to compile vboxdrv with linux 4.14 in my case.  https://www.virtualbox.org/ticket/17267
This require some change to driver build process. They must be cleaner way than copy the whole lib folder but I try to keep it simple. 
For information, it may only require VirtualBox binary and check_module_dependencies.sh