### PR TITLE
Add nautilus support | Mount home directory for Firefox / vscode / 

### DIFF
--- a/firefox/start.sh
+++ b/firefox/start.sh
@@ -1,0 +1,1 @@
+docker run -e DISPLAY=10.0.0.236:0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix firefox

--- a/firefox/start.sh
+++ b/firefox/start.sh
@@ -1,1 +1,1 @@
-docker run -e DISPLAY=10.0.0.236:0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix firefox
+docker run -e DISPLAY=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'):0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix firefox

--- a/geary/start.sh
+++ b/geary/start.sh
@@ -1,0 +1,1 @@
+docker run -e DISPLAY=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'):0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix geary

--- a/nautilus/Dockerfile
+++ b/nautilus/Dockerfile
@@ -1,0 +1,8 @@
+FROM fedora:latest
+RUN dnf install nautilus -y
+
+ENV LANG en-US
+
+COPY local.conf /etc/fonts/local.conf
+
+ENTRYPOINT [ "/usr/bin/nautilus" ]

--- a/nautilus/alpine/Dockerfile
+++ b/nautilus/alpine/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest
+
+LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+
+RUN apk add --no-cache \
+	alsa-lib \
+	ca-certificates \
+	firefox-esr \
+	hicolor-icon-theme \
+	mesa-dri-intel \
+	mesa-gl \
+	ttf-dejavu
+
+ENTRYPOINT ["/usr/bin/firefox"]

--- a/nautilus/local.conf
+++ b/nautilus/local.conf
@@ -1,0 +1,34 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+<match target="font">
+<edit mode="assign" name="rgba">
+<const>rgb</const>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="hinting">
+<bool>true</bool>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="hintstyle">
+<const>hintslight</const>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="antialias">
+<bool>true</bool>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="lcdfilter">
+<const>lcddefault</const>
+</edit>
+</match>
+<match target="font">
+<edit name="embeddedbitmap" mode="assign">
+<bool>false</bool>
+</edit>
+</match>
+</fontconfig>

--- a/nautilus/start.sh
+++ b/nautilus/start.sh
@@ -1,0 +1,1 @@
+docker run -e DISPLAY=10.0.0.236:0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix nautilus

--- a/nautilus/start.sh
+++ b/nautilus/start.sh
@@ -1,1 +1,1 @@
-docker run -e DISPLAY=10.0.0.236:0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix nautilus
+docker run -e DISPLAY=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'):0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix nautilus

--- a/slack/start.sh
+++ b/slack/start.sh
@@ -1,1 +1,1 @@
-docker run -e DISPLAY=10.0.0.236:0 -v $HOME:/root/  -v /tmp/.X11-unix:/tmp/.X11-unix slack
+docker run -e DISPLAY=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'):0 -v $HOME:/root/ -v /tmp/.X11-unix:/tmp/.X11-unix slack

--- a/slack/start.sh
+++ b/slack/start.sh
@@ -1,0 +1,1 @@
+docker run -e DISPLAY=10.0.0.236:0 -v $HOME:/root/  -v /tmp/.X11-unix:/tmp/.X11-unix slack

--- a/vscode/start.sh
+++ b/vscode/start.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-set -e
-set -o pipefail
-
-su user -p -c /usr/share/code/code
+docker run  -v $HOME:/home/user -e DISPLAY=10.0.0.236:0  -v /tmp/.X11-unix:/tmp/.X11-unix code

--- a/vscode/start.sh
+++ b/vscode/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run  -v $HOME:/home/user -e DISPLAY=10.0.0.236:0  -v /tmp/.X11-unix:/tmp/.X11-unix code
+docker run -e DISPLAY=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'):0 -v $HOME:/home/user -v /tmp/.X11-unix:/tmp/.X11-unix code


### PR DESCRIPTION
This PR adds nautilus support as well as adds a start.sh for slack/vscode. The start.sh for both, as well as firefox, mounts the $HOME directory to the home directory of the corresponding user the app is being run as. This PR also provides support to easily identify IP address for X11 forwarding. This PR was developed on Mac OSX and tested on Mac OSX.