### PR TITLE
Replaced and optimised shellcheck dockerfile

### DIFF
--- a/shellcheck/Dockerfile
+++ b/shellcheck/Dockerfile
@@ -1,4 +1,5 @@
-FROM haskell
+FROM debian:buster-slim
+
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
@@ -6,6 +7,6 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN cabal update && cabal install shellcheck
+RUN apt-get update && apt-get install -y shellcheck
 
 CMD ["shellcheck"]


### PR DESCRIPTION
I have updated the shellcheck dockerfile.

* Haskell images has some of the vulnerabilities.
* The image size was more than 1.68GB which was pretty much. So I minimized it to 100mb.

**Question** 
I was not sure about the Maintainer label though. Like it should be mine or yours. But for time being I am just putting yours.

The dockerfile is tested.....

/cc @jessfraz 
  