### PR TITLE
Add git dependency for vscode

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -28,6 +28,7 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable ma
 
 RUN apt-get update && apt-get -y install \
 	code \
+	git \
 	libasound2 \
 	libatk1.0-0 \
 	libcairo2 \


### PR DESCRIPTION
Visual Studio Code adds a warning if it can't find `git`, so I've added it as a dependency in the `Dockerfile`. This gets rid of the warning on my container. 

Thanks!

![vscode](https://user-images.githubusercontent.com/1638483/34960678-b77a345c-f9f0-11e7-8a90-c2667717c377.png)
