### PR TITLE
atom/Dockerfile: Use GitHub API to always download newest release

### DIFF
--- a/atom/Dockerfile
+++ b/atom/Dockerfile
@@ -43,8 +43,6 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV ATOM_VERSION 1.25.0
-
 # download the source
 RUN buildDeps=' \
 		ca-certificates \
@@ -53,7 +51,14 @@ RUN buildDeps=' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -sSL https://github.com/atom/atom/releases/download/v${ATOM_VERSION}/atom-amd64.deb -o /tmp/atom-amd64.deb \
+	&& curl -sSL \
+		$(curl -sSL https://api.github.com/repos/atom/atom/releases/latest | \
+			grep "browser_download_url" | \
+			grep "amd64.deb" | \
+			cut -d ":" -f 2,3 | \
+			tr --delete \" | \
+			tr --delete " ") \
+		-o /tmp/atom-amd64.deb \
 	&& dpkg -i /tmp/atom-amd64.deb \
 	&& rm -rf /tmp/*.deb \
 	&& apt-get purge -y --auto-remove $buildDeps


### PR DESCRIPTION
Hey,

this is just a suggestion to use the GitHub API to always download the newest release of atom without using a fixed version number. This makes updating things easier and can be applied to other Dockerfiles too. Let me know what you think of it.

GNU/Tang for life.