### PR TITLE
Machine parse-able Dockerfile comments

### DIFF
--- a/couchpotato/Dockerfile
+++ b/couchpotato/Dockerfile
@@ -12,6 +12,16 @@
 FROM alpine:latest
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
+# machine parsable metadata, for https://github.com/pycampers/dockapt
+LABEL "registry_image"="r.j3ss.co/couchpotato"
+LABEL "docker_run_flags"="-d \
+ 	--restart always \
+	-p 5050:5050 \
+ 	-v /etc/localtime:/etc/localtime:ro \
+ 	-v /volumes/couchpotato:/data \
+	--link transmission:transmission \
+ 	--name couchpotato"
+
 
 RUN apk add --no-cache \
 	ca-certificates \


### PR DESCRIPTION
I am trying to make this repo's docker file comments machine parse-able so i can use it in [this](https://github.com/pycampers/dockapt) project. 

This is the first image i am trying to work with and if it is successful, i plan to put these on every image, make it a standard of some sort. 

I would appreciate if you guys can see this as a collaborative effort to bring docker to the masses.

Thanks. 