### PR TITLE
Update Dockerfile to make it machine parse-able

### DIFF
--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -21,6 +21,12 @@
 FROM alpine:latest
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
+# machine parsable metadata, for https://github.com/pycampers/dockapt
+LABEL "registry_image"="r.j3ss.co/transmission"
+LABEL "docker_run_flags"="-d --name transmission \
+		-v ~/Downloads:/transmission/download \
+		-p 9091:9091 -p 51413:51413 -p 51413:51413/udp"
+
 RUN apk --no-cache add \
 	transmission-daemon \
 	&& mkdir -p /transmission/download \


### PR DESCRIPTION
couch potato has transmission has dependency and hence needs to be updated with the correct labels.

Btw I have another doubt.

Should allow dependencies to available to other packages
or should i make them available only to that respective package.