### PR TITLE
[slack] Add missing library

### DIFF
--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -39,6 +39,7 @@ RUN echo "deb https://packagecloud.io/slacktechnologies/slack/debian/ jessie mai
 
 RUN apt-get update && apt-get -y install \
 	libasound2 \
+	libgtk-3-0 \
 	libx11-xcb1 \
 	libxkbfile1 \
 	slack-desktop \


### PR DESCRIPTION
Fixes `/usr/lib/slack/slack: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory`