### PR TITLE
Fixed suite variable getting null value for nested repo as well.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -33,10 +33,9 @@ for f in "${files[@]}"; do
 		continue
 	fi
 
-	image=${f%Dockerfile}
-	base=${image%%\/*}
-	suite=${image##*\/}
 	build_dir=$(dirname $f)
+	base=${build_dir%%\/*}
+	suite=${build_dir##*\/}
 
 	if [[ -z "$suite" ]]; then
 		suite=latest


### PR DESCRIPTION
Signed-off-by: Umesh Yadav <umesh4257@gmail.com>

* Image and build_dir were getting the the same value so I removed one of them.
* suite variable which is supposed to get the nested directory name.
 for eg foo/bar/Dockerfile in this case suite should equal to bar but it was getting set to null because of the trailing slash.