### PR TITLE
Fixed suite variable getting null value for nested directory.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -33,9 +33,10 @@ for f in "${files[@]}"; do
 		continue
 	fi
 
-	build_dir=$(dirname $f)
-	base=${build_dir%%\/*}
-	suite=${build_dir##*\/}
+	build_dir=$(dirname "$f")
+	base="${build_dir%%\/*}"
+	suite="${build_dir##$base}"
+	suite="${suite##\/}"
 
 	if [[ -z "$suite" ]]; then
 		suite=latest


### PR DESCRIPTION
Signed-off-by: Umesh Yadav <umesh4257@gmail.com>

Sorry for the last PR, I should checked it properly before pushing. Here is the PR with proper fix. Here is the output of a test run.

```
windy@linux:~/github/dockerfiles$ ./test.sh
build_dir base suite
foo foo
foo foo latest
                       ---
Successfully built foo:latest with context foo
                       ---
build_dir base suite
foo/bar foo bar
foo/bar foo bar
                       ---
Successfully built foo:bar with context foo/bar
                       ---
```