### PR TITLE
Update Dockerfile

### DIFF
--- a/beeswithmachineguns/Dockerfile
+++ b/beeswithmachineguns/Dockerfile
@@ -5,6 +5,7 @@ RUN apk --no-cache add \
 	ca-certificates \
 	python \
 	py-boto \
+	py-future \
 	py-paramiko
 
 RUN buildDeps=' \


### PR DESCRIPTION
Fix bees import future error

```
$ docker run -it jessfraz/beeswithmachineguns
Unable to find image 'jess/beeswithmachineguns:latest' locally
latest: Pulling from jess/beeswithmachineguns
8e3ba11ec2a2: Pull complete 
3f5e2c615e06: Pull complete 
f21b8e1a9648: Pull complete 
Digest: sha256:288a6075a41a30ab53e5f16b3d616c2a42bc18cf118800f311de8581582157e7
Status: Downloaded newer image for jess/beeswithmachineguns:latest
Traceback (most recent call last):
  File "/usr/bin/bees", line 3, in <module>
    from beeswithmachineguns import main
  File "/usr/lib/python2.7/site-packages/beeswithmachineguns/main.py", line 28, in <module>
    from future import standard_library
ImportError: No module named future
```

After:

```
$ docker run  -it bees:latest
Usage: 
bees COMMAND [options]

Bees with Machine Guns

A utility for arming (creating) many bees (small EC2 instances) to attack
(load test) targets (web applications).

commands:
  up      Start a batch of load testing servers.
  attack  Begin the attack on a specific url.
  down    Shutdown and deactivate the load testing servers.
  report  Report the status of the load testing servers.
    

bees: error: Please enter a command.
```