### PR TITLE
Updated permissions for entrypoint

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -106,6 +106,7 @@ WORKDIR /config
 EXPOSE 3478/udp 8080 8081 8443 8843 8880 6789
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD ["java", "-Xmx1024M", "-jar", "/usr/lib/unifi/lib/ace.jar", "start"]


### PR DESCRIPTION
Made entrypoint.sh executable in the container to apply fix for https://github.com/jessfraz/dockerfiles/issues/407.