### PR TITLE
make coredns/Dockerfile use build stages

### DIFF
--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -1,32 +1,35 @@
-FROM alpine:latest
+FROM alpine:latest as builder
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
-RUN	apk --no-cache add \
-	ca-certificates
+RUN    apk --no-cache add \
+    ca-certificates
 
 ENV COREDNS_VERSION v1.2.2
 
-RUN buildDeps=' \
-		go \
-		git \
-		gcc \
-		g++ \
-		libc-dev \
-		libgcc \
-		make \
-	' \
-	set -x \
-	&& apk --no-cache add $buildDeps \
-	&& git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns /go/src/github.com/coredns/coredns \
-	&& cd /go/src/github.com/coredns/coredns \
-	&& make CHECKS="godeps" \
-	&& mv coredns /usr/bin/coredns \
-	&& apk del $buildDeps \
-	&& rm -rf /go \
-	&& echo "Build complete."
+RUN set -x \
+    && apk --no-cache add \
+        go \
+        git \
+        gcc \
+        g++ \
+        libc-dev \
+        libgcc \
+        make \
+    && git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns /go/src/github.com/coredns/coredns \
+    && cd /go/src/github.com/coredns/coredns \
+    && make CHECKS="godeps" \
+    && mv coredns /usr/bin/coredns \
+    && echo "Build complete."
 
+FROM alpine:latest
+
+RUN apk add --no-cache \
+    bash \
+    tar
+
+COPY --from=builder /usr/bin/coredns /usr/bin/coredns
 
 ENTRYPOINT [ "coredns", "-log" ]

--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -26,10 +26,6 @@ RUN set -x \
 
 FROM alpine:latest
 
-RUN apk add --no-cache \
-    bash \
-    tar
-
 COPY --from=builder /usr/bin/coredns /usr/bin/coredns
 
 ENTRYPOINT [ "coredns", "-log" ]


### PR DESCRIPTION
Fixes #419 

This change uses build stages to create the coredns container.

Questions:
I followed the terraform/Dockerfile fairly closely, why is the build copied to /usr/bin/terraform before the next stage?

Thanks for posting these first commit issues 🙌