### PR TITLE
make transfer-sh/Dockerfile use build stages

### DIFF
--- a/transfer-sh/Dockerfile
+++ b/transfer-sh/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest as builder
 LABEL maintainer "Jess Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -9,7 +9,8 @@ RUN	apk --no-cache add \
 
 ENV TRANSFER_SH_VERSION master
 
-RUN buildDeps=' \
+RUN	set -x \
+	&& apk --no-cache add \
 		bash \
 		go \
 		git \
@@ -18,16 +19,15 @@ RUN buildDeps=' \
 		libc-dev \
 		libgcc \
 		make \
-	' \
-	set -x \
-	&& apk --no-cache add $buildDeps \
 	&& git clone --depth 1 --branch ${TRANSFER_SH_VERSION} https://github.com/dutchcoders/transfer.sh /go/src/github.com/dutchcoders/transfer.sh \
 	&& cd /go/src/github.com/dutchcoders/transfer.sh \
 	&& go build -o /usr/bin/transfer.sh \
-	&& apk del $buildDeps \
-	&& rm -rf /go \
 	&& echo "Build complete."
 
+# Create a clean image without build dependencies
+FROM alpine:latest
+
+COPY --from=builder /usr/bin/transfer.sh /usr/bin/transfer.sh
 
 ENTRYPOINT [ "transfer.sh" ]
 CMD [ "--help" ]


### PR DESCRIPTION
Removed `buildDeps` since they no longer need to be removed and added second stage to create a clean image from the build.