### PR TITLE
vlc: Qt complains, needs xcb, switch to stretch

### DIFF
--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -9,7 +9,7 @@
 #	--name vlc \
 #	jess/vlc
 #
-FROM debian:buster-slim
+FROM debian:stretch-slim
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Previously this Dockerfile was using buster, but would throw the error:
```
Could not find the Qt platform plugin "xcb" in ""
```

Switching to stretch solves the problem.

Similar to issue:
https://github.com/jessfraz/dockerfiles/issues/401

I realize you *just* switched to buster for this image, however I could not resolve the problem in buster and thought this fix would be welcome.