### PR TITLE
jess/firefox: Allow ALSA and pulseaudio sound (#410). Fix tab crashes (#376, #360).

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -8,12 +8,14 @@ RUN apt-get update && apt-get install -y \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21 \
 	&& echo "deb http://ppa.launchpad.net/mozillateam/firefox-next/ubuntu xenial main" >> /etc/apt/sources.list.d/firefox.list \
 	&& apt-get update && apt-get install -y \
+        apulse \
 	ca-certificates \
 	firefox \
 	hicolor-icon-theme \
 	libasound2 \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
+        libpulse0 \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -21,4 +23,10 @@ ENV LANG en-US
 
 COPY local.conf /etc/fonts/local.conf
 
-ENTRYPOINT [ "/usr/bin/firefox" ]
+RUN echo 'pref("browser.tabs.remote.autostart", false);' >> /etc/firefox/syspref.js
+
+RUN echo "#! /bin/bash \n\
+[ -e /dev/snd ] && exec apulse firefox || exec firefox \n\
+" >/usr/local/bin/startfirefox && chmod +x /usr/local/bin/startfirefox
+
+ENTRYPOINT [ "/usr/local/bin/startfirefox" ]


### PR DESCRIPTION
 - Sets `browser.tabs.remote.autostart` = `false` to avoid tab crashes. #376, #360
 - Installs `apulse` to provide fake pulseaudio to allow ALSA sound again. #410
 - Installs `libpulse0` to allow real pulseaudio sound. #410#issuecomment-422969073
 - Creates ENTRYPOINT wrapper script to run with or without apulse wrapper, depending on given or missing `/dev/snd`. 
   - Native ALSA support probably fails due to firefox bug. 
   - `apulse firefox` wraps firefox pulseaudio calls and forwards them to ALSA.
   - To run jess/firefox with real pulseaudio from host, `apulse` must not be used.