### PR TITLE
1. Fix occassional GPG key retrieval failures

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install gosu
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.11
 RUN set -ex; \
 	\
 	fetchDeps=' \
@@ -56,7 +56,13 @@ RUN set -ex; \
 	\
 # verify the signature
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    for server in $(shuf -e ha.pool.sks-keyservers.net \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+    done && \
 	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
 	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\


### PR DESCRIPTION
GPG key retrieval from the single server failed on each and every
build for me. I found, and adopted, a solution recorded under issue #35 at
tianon/gosu:
https://github.com/tianon/gosu/issues/35#issuecomment-299205512

2. Update gosu to latest version whilst we're at it.

Container tested for 24 hours, no observed issues.