### PR TITLE
procps package is required for ps

### DIFF
--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
 	ca-certificates \
 	curl \
 	gnupg \
+	procps \
 	--no-install-recommends
 
 # Add the skype debian repo


### PR DESCRIPTION
The run-skype-and-wait-for-exit script requires the ps binary but it isn't available as procps package isn't installed.