### PR TITLE
Add dependency to enable sound in Spotify

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -23,6 +23,7 @@ RUN	apt-get update && apt-get install -y \
 	alsa-utils \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
+	libpulse0 \
 	spotify-client \
 	xdg-utils \
 	--no-install-recommends \


### PR DESCRIPTION
Hi,

Spotify crashes if run with pulseaudio server configuration, I fixed it by adding libpulse0 to the dependencies. Let me know if there was a better way to fix it.

Thanks,