### PR TITLE
Fix maintainer labels

### DIFF
--- a/ab/Dockerfile
+++ b/ab/Dockerfile
@@ -5,7 +5,7 @@
 # 	jess/ab
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	apache2-ssl \

--- a/afterthedeadline/Dockerfile
+++ b/afterthedeadline/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8-alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/android-tools/Dockerfile
+++ b/android-tools/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	adb \

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -8,7 +8,7 @@
 # 	ansible all -m ping
 #
 FROM alpine:latest
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN builddeps=' \
 		python-dev \

--- a/apt-file/Dockerfile
+++ b/apt-file/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	apt-file \

--- a/atom/Dockerfile
+++ b/atom/Dockerfile
@@ -21,7 +21,7 @@
 # Base docker image
 FROM debian:buster-slim
 
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Tell debconf to run in non-interactive mode
 ENV DEBIAN_FRONTEND noninteractive

--- a/audacity/Dockerfile
+++ b/audacity/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	audacity \

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/azure-cli/Dockerfile
+++ b/azure-cli/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	bash

--- a/bcc-tools/Dockerfile
+++ b/bcc-tools/Dockerfile
@@ -7,7 +7,7 @@
 #	r.j3ss.co/bcc-tools
 #
 FROM debian:buster-slim
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /usr/share/bcc/tools:$PATH
 

--- a/beeswithmachineguns/Dockerfile
+++ b/beeswithmachineguns/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/browsh/Dockerfile
+++ b/browsh/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install bash and other deps so we have them.
 RUN apt-get update && apt-get install -y \

--- a/cathode/Dockerfile
+++ b/cathode/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	build-essential \

--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	bash \

--- a/cf-reset-cache/Dockerfile
+++ b/cf-reset-cache/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/checkup/Dockerfile
+++ b/checkup/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apk --no-cache add \
 	ca-certificates \

--- a/cheese/Dockerfile
+++ b/cheese/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	cheese \

--- a/chrome/beta/Dockerfile
+++ b/chrome/beta/Dockerfile
@@ -20,7 +20,7 @@
 
 # Base docker image
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install Chrome
 RUN apt-get update && apt-get install -y \

--- a/chrome/stable/Dockerfile
+++ b/chrome/stable/Dockerfile
@@ -20,7 +20,7 @@
 
 # Base docker image
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install Chrome
 RUN apt-get update && apt-get install -y \

--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -19,7 +19,7 @@
 
 # Base docker image
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install Chromium
 RUN apt-get update && apt-get install -y \

--- a/clisp/Dockerfile
+++ b/clisp/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache \
 RUN git clone https://github.com/brendandburns/cl-k8s.git /cl-k8s
 
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	--repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \

--- a/cloudapp/Dockerfile
+++ b/cloudapp/Dockerfile
@@ -1,5 +1,5 @@
 FROM	ruby:alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	libcurl

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:latest as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/couchpotato/Dockerfile
+++ b/couchpotato/Dockerfile
@@ -10,7 +10,7 @@
 # 	jess/couchpotato
 #
 FROM python:2-alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # machine parsable metadata, for https://github.com/pycampers/dockapt
 LABEL "registry_image"="r.j3ss.co/couchpotato"

--- a/dcos-cli/Dockerfile
+++ b/dcos-cli/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/debootstrap/Dockerfile
+++ b/debootstrap/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/distcc/Dockerfile
+++ b/distcc/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/doctor/Dockerfile
+++ b/doctor/Dockerfile
@@ -16,7 +16,7 @@
 
 # Base docker image
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install emacs:
 # Note: Emacs is only community repo -> https://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64

--- a/dunnet/Dockerfile
+++ b/dunnet/Dockerfile
@@ -16,7 +16,7 @@
 
 # Base docker image
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install emacs:
 # Note: Emacs is only in community repo -> https://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64

--- a/evince/Dockerfile
+++ b/evince/Dockerfile
@@ -8,7 +8,7 @@
 #
 
 FROM alpine:latest
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apk --no-cache add \
 	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	dirmngr \

--- a/firefox/alpine/Dockerfile
+++ b/firefox/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apk add --no-cache \
 	alsa-lib \

--- a/fleet/Dockerfile
+++ b/fleet/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine AS builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/fontforge/Dockerfile
+++ b/fontforge/Dockerfile
@@ -11,7 +11,7 @@
 
 # Base docker image
 FROM ubuntu:16.04
-LABEL maintainer "Axel Svensson <foss@axelsvensson.com>"
+LABEL maintainer="Axel Svensson <foss@axelsvensson.com>"
 
 RUN  apt-get update \
   && apt-get install -y \

--- a/fontpatcher/Dockerfile
+++ b/fontpatcher/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	python-fontforge \

--- a/freeradius/Dockerfile
+++ b/freeradius/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
     freeradius \

--- a/gcalcli/Dockerfile
+++ b/gcalcli/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV HOME /home/gcalcli
 

--- a/gcc/Dockerfile
+++ b/gcc/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	gcc \

--- a/geary/Dockerfile
+++ b/geary/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	geary \

--- a/ghostscript/Dockerfile
+++ b/ghostscript/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ghostscript

--- a/gimp/Dockerfile
+++ b/gimp/Dockerfile
@@ -9,7 +9,7 @@
 #	jess/gimp
 #
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	gimp \

--- a/github-dev/Dockerfile
+++ b/github-dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	bash \

--- a/gitiles/Dockerfile
+++ b/gitiles/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 

--- a/gitserver/Dockerfile
+++ b/gitserver/Dockerfile
@@ -6,7 +6,7 @@
 # 	--name gitserver \
 # 	jess/gitserver
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV HOME /root
 

--- a/glxgears/Dockerfile
+++ b/glxgears/Dockerfile
@@ -7,7 +7,7 @@
 
 # Base docker image
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install all the things
 RUN apt-get update && apt-get install -y \

--- a/gmail-britta/Dockerfile
+++ b/gmail-britta/Dockerfile
@@ -1,5 +1,5 @@
 FROM	ruby:alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	coreutils

--- a/gnuplot/Dockerfile
+++ b/gnuplot/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	--repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \

--- a/gparted/Dockerfile
+++ b/gparted/Dockerfile
@@ -18,7 +18,7 @@
 
 # Base docker image
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install Gparted and its dependencies
 RUN apt-get update && apt-get install -y \

--- a/guetzli/Dockerfile
+++ b/guetzli/Dockerfile
@@ -6,7 +6,7 @@
 # 	--verbose /tmp/example.jpg /tmp/example.compressed.jpg
 
 FROM alpine:latest
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apk --no-cache add \
 		libpng \

--- a/hollywood/Dockerfile
+++ b/hollywood/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/htop/Dockerfile
+++ b/htop/Dockerfile
@@ -5,7 +5,7 @@
 # 	jess/htop
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	htop

--- a/htpasswd/Dockerfile
+++ b/htpasswd/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	apache2-utils

--- a/httpie/Dockerfile
+++ b/httpie/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/iceweasel/Dockerfile
+++ b/iceweasel/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	hicolor-icon-theme \

--- a/imagemagick/Dockerfile
+++ b/imagemagick/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	imagemagick

--- a/imagemin/Dockerfile
+++ b/imagemin/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/imagemin
 #
 FROM node:alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	file \

--- a/inkscape/Dockerfile
+++ b/inkscape/Dockerfile
@@ -6,7 +6,7 @@
 #	jess/inkscape
 #
 FROM ubuntu:16.04
-LABEL maintainer "Daniel Romero <infoslack@gmail.com>"
+LABEL maintainer="Daniel Romero <infoslack@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/john/Dockerfile
+++ b/john/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/k8scan/Dockerfile
+++ b/k8scan/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/keepass2/Dockerfile
+++ b/keepass2/Dockerfile
@@ -19,7 +19,7 @@
 #
 
 FROM debian:sid-slim
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/keepassxc/Dockerfile
+++ b/keepassxc/Dockerfile
@@ -9,7 +9,7 @@
 #		jess/keepassxc
 #
 FROM alpine:latest
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 ENV KEEPASSXC_VERSION 2.3.4
 

--- a/kernel-builder/Dockerfile
+++ b/kernel-builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM r.j3ss.co/wireguard:install
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	bash \

--- a/kvm/Dockerfile
+++ b/kvm/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/kvm
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	iptables \

--- a/libreoffice/Dockerfile
+++ b/libreoffice/Dockerfile
@@ -11,7 +11,7 @@
 #	jess/libreoffice
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	--repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \

--- a/libvirt-client/Dockerfile
+++ b/libvirt-client/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	libvirt-client

--- a/lilyterm/Dockerfile
+++ b/lilyterm/Dockerfile
@@ -6,7 +6,7 @@
 
 # Base docker image
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install all the things
 RUN apt-get update && apt-get install -y \

--- a/lkp-tests/Dockerfile
+++ b/lkp-tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/lpass/Dockerfile
+++ b/lpass/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/lynx/Dockerfile
+++ b/lynx/Dockerfile
@@ -5,7 +5,7 @@
 #	jess/lynx github.com/jessfraz
 #
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	lynx \

--- a/mailgun/Dockerfile
+++ b/mailgun/Dockerfile
@@ -1,5 +1,5 @@
 FROM r.j3ss.co/curl
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	bash

--- a/mailman/Dockerfile
+++ b/mailman/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # run
 # docker run -d -p 1234:80 -p 25:25 jess/mailman

--- a/masscan/Dockerfile
+++ b/masscan/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/mc/Dockerfile
+++ b/mc/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 		glib \

--- a/mdp/Dockerfile
+++ b/mdp/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/metasploit/Dockerfile
+++ b/metasploit/Dockerfile
@@ -1,5 +1,5 @@
 FROM r.j3ss.co/kalilinux
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     metasploit-framework \

--- a/micro/Dockerfile
+++ b/micro/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/mitmproxy/Dockerfile
+++ b/mitmproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV LANG=en_US.UTF-8
 

--- a/mpd/Dockerfile
+++ b/mpd/Dockerfile
@@ -9,7 +9,7 @@
 #	jess/mpd
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	mpc \

--- a/mpsyt/Dockerfile
+++ b/mpsyt/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
-LABEL maintainer "Justin Garrison <justinleegarrison@gmail.com>"
+LABEL maintainer="Justin Garrison <justinleegarrison@gmail.com>"
 
 RUN apk add --no-cache \
 	mplayer \

--- a/mutt/Dockerfile
+++ b/mutt/Dockerfile
@@ -9,7 +9,7 @@
 #	jess/mutt
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN addgroup -g 1000 user \
 	&& adduser -D -h /home/user -G user -u 1000 user

--- a/ncmpc/Dockerfile
+++ b/ncmpc/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/ncmpc
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ncmpc \

--- a/neoman/Dockerfile
+++ b/neoman/Dockerfile
@@ -10,7 +10,7 @@
 #	jess/neoman
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/nerdy/Dockerfile
+++ b/nerdy/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/nes/Dockerfile
+++ b/nes/Dockerfile
@@ -8,7 +8,7 @@
 # 	jess/nes /games/zelda.rom
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	binutils \

--- a/netcat/Dockerfile
+++ b/netcat/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	netcat \

--- a/nginx-extras/Dockerfile
+++ b/nginx-extras/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/nmap/Dockerfile
+++ b/nmap/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	nmap \

--- a/nomad/Dockerfile
+++ b/nomad/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.10-alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/notify-osd/Dockerfile
+++ b/notify-osd/Dockerfile
@@ -18,7 +18,7 @@
 #	jess/notify-osd
 
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	at-spi2-core \

--- a/now/Dockerfile
+++ b/now/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	ca-certificates \

--- a/nzbget/Dockerfile
+++ b/nzbget/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2-alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV LANG "en_US.UTF-8"
 ENV LANGUAGE "en_US.UTF-8"

--- a/oauth2-proxy/Dockerfile
+++ b/oauth2-proxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apk --no-cache add \
 	ca-certificates \

--- a/osquery/Dockerfile
+++ b/osquery/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/pandoc/Dockerfile
+++ b/pandoc/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	pandoc \

--- a/perkeep/Dockerfile
+++ b/perkeep/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.10-alpine AS builder
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apk --no-cache add \
 	ca-certificates \

--- a/pivman/Dockerfile
+++ b/pivman/Dockerfile
@@ -10,7 +10,7 @@
 #	jess/pivman
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/plex-home-theater/Dockerfile
+++ b/plex-home-theater/Dockerfile
@@ -7,7 +7,7 @@
 # 	jess/plex-home-theater
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/pms/Dockerfile
+++ b/pms/Dockerfile
@@ -6,7 +6,7 @@
 #	jess/pms
 #
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	pms \

--- a/pond/Dockerfile
+++ b/pond/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:latest as builder
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/powershell/Dockerfile
+++ b/powershell/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch-slim
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 ENV POWERSHELL_VERSION 6.1.1
 

--- a/privoxy/Dockerfile
+++ b/privoxy/Dockerfile
@@ -11,7 +11,7 @@
 # 	jess/privoxy
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	privoxy

--- a/protocol/Dockerfile
+++ b/protocol/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "James Abley <james.abley@gmail.com>"
+LABEL maintainer="James Abley <james.abley@gmail.com>"
 
 RUN buildDeps=' \
                ca-certificates \

--- a/pulseaudio/Dockerfile
+++ b/pulseaudio/Dockerfile
@@ -10,7 +10,7 @@
 #	jess/pulseaudio
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	alsa-utils \

--- a/radarr/Dockerfile
+++ b/radarr/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV LANG "en_US.UTF-8"
 ENV LANGUAGE "en_US.UTF-8"

--- a/rainbowstream/Dockerfile
+++ b/rainbowstream/Dockerfile
@@ -8,7 +8,7 @@
 #	jess/rainbowstream
 #
 FROM python:2-alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	build-base \

--- a/rdesktop/Dockerfile
+++ b/rdesktop/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	libgssapi-krb5-2 \

--- a/registry-auth/Dockerfile
+++ b/registry-auth/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2-alpine AS buildbase
-LABEL maintainer "Jess Frazelle <jess@linux.com>"
+LABEL maintainer="Jess Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	bash \

--- a/remmina/Dockerfile
+++ b/remmina/Dockerfile
@@ -9,7 +9,7 @@
 #	jess/remmina
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/ricochet/Dockerfile
+++ b/ricochet/Dockerfile
@@ -10,7 +10,7 @@
 # 	jess/ricochet
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/routersploit/Dockerfile
+++ b/routersploit/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 ENV ROUTERSPLOIT_VERSION v3.4.0
 

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -11,7 +11,7 @@
 
 # Base docker image
 FROM debian:jessie-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install Rstudio deps
 RUN apt-get update && apt-get install -y \

--- a/rt-tests/Dockerfile
+++ b/rt-tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	rt-tests \

--- a/runc-rootless/Dockerfile
+++ b/runc-rootless/Dockerfile
@@ -15,7 +15,7 @@ RUN git clone https://github.com/jessfraz/runc.git "$GOPATH/src/github.com/openc
 	&& mv runc /usr/bin/runc
 
 FROM alpine:latest
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 RUN apk add --no-cache \
 	bash \
 	shadow \

--- a/s3cmd/Dockerfile
+++ b/s3cmd/Dockerfile
@@ -8,7 +8,7 @@
 #	jess/s3cmd
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/scudcloud/Dockerfile
+++ b/scudcloud/Dockerfile
@@ -13,7 +13,7 @@
 #	jess/scudcloud
 
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/shellcheck/Dockerfile
+++ b/shellcheck/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	file \

--- a/shorewall/Dockerfile
+++ b/shorewall/Dockerfile
@@ -7,7 +7,7 @@
 # 	jess/shorewall
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	shorewall \

--- a/sickbeard/Dockerfile
+++ b/sickbeard/Dockerfile
@@ -10,7 +10,7 @@
 # 	jess/sickbeard
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 
 RUN apk add --no-cache \

--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -15,7 +15,7 @@
 #	jess/slack "$@"
 
 FROM debian:jessie-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/slapd/Dockerfile
+++ b/slapd/Dockerfile
@@ -25,7 +25,7 @@
 # host firewall is unconfigured.
 #
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && LC_ALL=C DEBIAN_FRONTEND=noninteractive \
 	apt-get install -y \

--- a/sonarr/Dockerfile
+++ b/sonarr/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV LANG "en_US.UTF-8"
 ENV LANGUAGE "en_US.UTF-8"

--- a/spotify-wine/Dockerfile
+++ b/spotify-wine/Dockerfile
@@ -10,7 +10,7 @@
 #	jess/spotify-wine bash
 #
 FROM r.j3ss.co/wine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ADD https://download.scdn.co/SpotifySetup.exe /usr/src/SpotifySetup.exe
 

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -11,7 +11,7 @@
 #	jess/spotify
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apt-get update && apt-get install -y \
 	dirmngr \

--- a/stress/Dockerfile
+++ b/stress/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	stress \

--- a/sublime-text-3/Dockerfile
+++ b/sublime-text-3/Dockerfile
@@ -24,7 +24,7 @@
 #
 
 FROM debian:buster-slim
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apt-get update && apt-get -y install \
 	apt-transport-https \

--- a/t/Dockerfile
+++ b/t/Dockerfile
@@ -1,5 +1,5 @@
 FROM	ruby:alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	ca-certificates

--- a/tarsnap/Dockerfile
+++ b/tarsnap/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/telnet/Dockerfile
+++ b/telnet/Dockerfile
@@ -4,7 +4,7 @@
 #	jess/telnet towel.blinkenlights.nl
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache --virtual \
 	busybox-extras

--- a/termboy/Dockerfile
+++ b/termboy/Dockerfile
@@ -18,7 +18,7 @@
 
 # Base docker image
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/tetris/Dockerfile
+++ b/tetris/Dockerfile
@@ -16,7 +16,7 @@
 
 # Base docker image
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install emacs:
 # Note: Emacs is only in community repo -> https://pkgs.alpinelinux.org/packages?package=emacs&repo=all&arch=x86_64

--- a/texlive/Dockerfile
+++ b/texlive/Dockerfile
@@ -7,7 +7,7 @@
 # https://github.com/andygrunwald/FOM-LaTeX-Template
 
 FROM debian:buster-slim
-LABEL maintainer "Christian Koep <christiankoep@gmail.com>"
+LABEL maintainer="Christian Koep <christiankoep@gmail.com>"
 
 RUN apt-get update && apt-get install -y \
     texlive-full \

--- a/tor-browser/alpha/Dockerfile
+++ b/tor-browser/alpha/Dockerfile
@@ -8,7 +8,7 @@
 #	jess/tor-browser:alpha
 #
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/tor-browser/stable/Dockerfile
+++ b/tor-browser/stable/Dockerfile
@@ -8,7 +8,7 @@
 #	jess/tor-browser
 #
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	ca-certificates \

--- a/tor-proxy/Dockerfile
+++ b/tor-proxy/Dockerfile
@@ -8,7 +8,7 @@
 # 	jess/tor-proxy
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	tor

--- a/tor-relay/Dockerfile
+++ b/tor-relay/Dockerfile
@@ -17,7 +17,7 @@
 # 		jess/tor-relay -f /etc/tor/torrc.exit
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	bash \

--- a/tor-router/Dockerfile
+++ b/tor-router/Dockerfile
@@ -9,7 +9,7 @@
 # 	jess/tor-router
 #
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	tor \

--- a/traceroute/Dockerfile
+++ b/traceroute/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	traceroute \

--- a/transfer-sh/Dockerfile
+++ b/transfer-sh/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer "Jess Frazelle <jess@linux.com>"
+LABEL maintainer="Jess Frazelle <jess@linux.com>"
 
 RUN	apk --no-cache add \
 	ca-certificates \

--- a/transmission-ui/Dockerfile
+++ b/transmission-ui/Dockerfile
@@ -18,7 +18,7 @@
 
 # Base docker image
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Install transmission and its dependencies
 RUN apt-get update && apt-get install -y \

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -19,7 +19,7 @@
 
 # Base docker image
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # machine parsable metadata, for https://github.com/pycampers/dockapt
 LABEL "registry_image"="r.j3ss.co/transmission"

--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -1,5 +1,5 @@
 FROM	ruby:alpine
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	ca-certificates \

--- a/troff/Dockerfile
+++ b/troff/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	heirloom-doctools

--- a/unixbench/Dockerfile
+++ b/unixbench/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	bash \

--- a/vagrant/Dockerfile
+++ b/vagrant/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN	apt-get update && apt-get install -y \
 	bridge-utils \

--- a/viewdocs/Dockerfile
+++ b/viewdocs/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/virt-viewer/Dockerfile
+++ b/virt-viewer/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:sid-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	libgl1-mesa-dri \

--- a/virtualbox/Dockerfile
+++ b/virtualbox/Dockerfile
@@ -29,7 +29,7 @@
 # 	rm -rf /usr/share/virtualbox /usr/lib/virtualbox
 #
 FROM debian:stretch-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/vlc/Dockerfile
+++ b/vlc/Dockerfile
@@ -10,7 +10,7 @@
 #	jess/vlc
 #
 FROM debian:stretch-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	libgl1-mesa-dri \

--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -10,7 +10,7 @@
 #    jess/vscode
 
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # Tell debconf to run in non-interactive mode
 ENV DEBIAN_FRONTEND noninteractive

--- a/wargames/Dockerfile
+++ b/wargames/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ncurses

--- a/watchtower/Dockerfile
+++ b/watchtower/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer "Jess Frazelle <jess@linux.com>"
+LABEL maintainer="Jess Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/wine/Dockerfile
+++ b/wine/Dockerfile
@@ -1,6 +1,6 @@
 # Wine docker image base
 FROM debian:buster-slim
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 # install wine
 RUN apt-get update && apt-get install -y \

--- a/wireguard/install/Dockerfile
+++ b/wireguard/install/Dockerfile
@@ -9,7 +9,7 @@
 # 	r.j3ss.co/wireguard:install
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	build-base \

--- a/wireguard/tools/Dockerfile
+++ b/wireguard/tools/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/wireshark/Dockerfile
+++ b/wireshark/Dockerfile
@@ -8,7 +8,7 @@
 #	jess/wireshark
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \

--- a/wrk/Dockerfile
+++ b/wrk/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk --no-cache add \
 	ca-certificates \

--- a/ykman/Dockerfile
+++ b/ykman/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/ykpersonalize
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	pcscd \

--- a/ykpersonalize/Dockerfile
+++ b/ykpersonalize/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/ykpersonalize
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/yubico-piv-tool/Dockerfile
+++ b/yubico-piv-tool/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/yubico-piv-tool
 #
 FROM ubuntu:16.04
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \

--- a/znc/Dockerfile
+++ b/znc/Dockerfile
@@ -7,7 +7,7 @@
 #	jess/znc
 #
 FROM alpine:latest
-LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+LABEL maintainer="Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \


### PR DESCRIPTION
No on really cares, but labels are supposed to have a `=` between `<key>` and `<value>`.

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated