### PR TITLE
gparted update: procps and usage

### DIFF
--- a/gparted/Dockerfile
+++ b/gparted/Dockerfile
@@ -13,6 +13,8 @@
 #
 #	docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
 #		--device=/dev/sda:/dev/sda \
+#		--device=/dev/mem:/dev/mem \
+#		--cap-add SYS_RAWIO \
 #		-e DISPLAY=unix$DISPLAY gparted
 #
 

--- a/gparted/Dockerfile
+++ b/gparted/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
 	dosfstools \
 	gparted \
 	libcanberra-gtk-module \
+	procps \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
1. added `procps` to suppress `/usr/sbin/gparted: 1: /usr/sbin/gparted: ps: not found` errors. 
2. updated example usage command with `/dev/mem` device and capability to suppress `/dev/mem: No such file or directory` errors.