### PR TITLE
Bump Unifi controller to 5.10.20

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get update && apt-get install -y \
 
 # unifi version
 # From: https://www.ubnt.com/download/unifi/
-ENV UNIFI_VERSION "5.10.19"
+ENV UNIFI_VERSION "5.10.20"
 
 # install unifi
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This commit bumps the version of the Unifi controller from 5.10.19 to 5.10.20.

Supersedes #459