### PR TITLE
Allow to pass command line arguments to dockerized firefox

### DIFF
--- a/firefox/entrypoint.sh
+++ b/firefox/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -e /dev/snd ]]; then
-	exec apulse firefox
+	exec apulse firefox $@
 else
-	exec firefox
+	exec firefox $@
 fi

--- a/firefox/entrypoint.sh
+++ b/firefox/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -e /dev/snd ]]; then
-	exec apulse firefox $@
+	exec apulse firefox "$@"
 else
-	exec firefox $@
+	exec firefox "$@"
 fi


### PR DESCRIPTION
Hi I cloned your repo with Docker images some time ago. I wanted to use dockerized Firefox. I also wanted to start dockerized Firefox and pass command line arguments to it (--private-window, --url etc.). I found out that your entrypoint script didn't allow that so I made this simple change.