### PR TITLE
Follow Dockerfile best practice by verifying file download against GPG signature (curl)

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -22,7 +22,11 @@ RUN set -x \
 		nghttp2-dev \
 		openssl-dev \
 		perl \
+		gnupg \
 	&& wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.bz2 \
+	&& wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.bz2.asc \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2 \
+	&& gpg --verify curl-$CURL_VERSION.tar.bz2.asc \
     && tar xjvf curl-$CURL_VERSION.tar.bz2 \
     && rm curl-$CURL_VERSION.tar.bz2 \
     && ( \


### PR DESCRIPTION
Dockerfile to build **curl** container now verifies the tarball download against the published GPG signature as is described in the Dockerfile best practices for official images guide.