### PR TITLE
fix(cf-reset-cache): handle s3 bucket names with periods in them

### DIFF
--- a/cf-reset-cache/Dockerfile
+++ b/cf-reset-cache/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apk add --no-cache \
 	ca-certificates \
-	py-boto
+	py-pip \
+	&& pip install boto3
 
 
 COPY ./reset-cache.py /bin/reset-cache.py


### PR DESCRIPTION
Sorry in advance. I'm not very familiar with Boto2/3/Python.

I was taking a look at your [Blog's Makefile](https://github.com/jessfraz/blog/blob/master/Makefile#L37) and wanted to use your purge-cache method. I have a bucket with a period in its name (dustinspecker.com) and I was getting SSL Certificate Errors thrown by boto (maybe python itself?). Did some investigation and got something working on my end. I updated cf-reset-cache to use boto3 to handle the change in how python2 handles SSL according to https://github.com/boto/boto/issues/2836 .

Happy to discuss alternative approaches. Also good chance I over-complicated this as it looks like your blog's bucket also has a period in it (blog.jessfraz.com), and I'm not understanding why it doesn't work for me.