### PR TITLE
Fix missing python dependency and add some conveniences to weechat

### DIFF
--- a/weechat/Dockerfile
+++ b/weechat/Dockerfile
@@ -1,13 +1,11 @@
 FROM alpine:latest
 
 RUN apk add --no-cache \
-	weechat \
-	weechat-perl \
-	weechat-python
+	weechat
 
 ENV HOME /home/user
 
-RUN adduser -S user \
+RUN adduser -D user \
 	&& chown -R user $HOME
 
 WORKDIR $HOME

--- a/weechat/Dockerfile
+++ b/weechat/Dockerfile
@@ -1,3 +1,11 @@
+# Run weechat in a container
+#
+# docker run -it \
+#	-v $HOME/.weechat/home/user/.weechat \
+#	--name weechat \
+#	jess/weechat
+#
+
 FROM alpine:latest
 
 RUN apk add --no-cache \

--- a/weechat/Dockerfile
+++ b/weechat/Dockerfile
@@ -9,11 +9,16 @@
 FROM alpine:latest
 
 RUN apk add --no-cache \
-	weechat
+	weechat \
+	weechat-perl \
+	weechat-python \
+	python
 
+ARG RUNTIME_UID
+ENV RUNTIME_UID ${UID:-1000}
 ENV HOME /home/user
 
-RUN adduser -D user \
+RUN adduser -D user -u ${RUNTIME_UID} \
 	&& chown -R user $HOME
 
 WORKDIR $HOME


### PR DESCRIPTION
This PR adds the `python` package which appeared to be a missing dependency of `weechat-python`. An alternative would be to just remove `weechat-python` and `weechat-perl` for the sake of image size as this new dependency raised the image size up to `93MB` from `19MB` as compared to the image without each of the above.

This also adds a run comment and allows for an alternate UID to be passed at image build time.