### PR TITLE
Add UID args and HOME env consistently to weechat images

### DIFF
--- a/wee-slack/Dockerfile
+++ b/wee-slack/Dockerfile
@@ -23,11 +23,13 @@ RUN apk add --no-cache \
 
 RUN pip install websocket-client
 
+ARG RUNTIME_UID
+ENV RUNTIME_UID ${UID:-1000}
 ENV HOME /home/user
 
 ADD https://raw.githubusercontent.com/rawdigits/wee-slack/master/wee_slack.py /home/user/.weechat/python/autoload/wee_slack.py
 
-RUN adduser -S user -h $HOME \
+RUN adduser -S user -u ${RUNTIME_UID} -h $HOME \
 	&& chown -R user $HOME
 
 WORKDIR $HOME

--- a/weechat-matrix/Dockerfile
+++ b/weechat-matrix/Dockerfile
@@ -28,9 +28,11 @@ RUN apk add --no-cache \
 	weechat-python \
 	--repository https://dl-4.alpinelinux.org/alpine/edge/testing
 
+ARG RUNTIME_UID
+ENV RUNTIME_UID ${UID:-1000}
 ENV HOME /home/user
 
-RUN adduser -S user -h $HOME \
+RUN adduser -S user -u ${RUNTIME_UID} -h $HOME \
 	&& chown -R user $HOME \
 	&& cd $HOME \
 	&& git clone https://github.com/poljar/weechat-matrix.git \

--- a/weechat/Dockerfile
+++ b/weechat/Dockerfile
@@ -18,7 +18,7 @@ ARG RUNTIME_UID
 ENV RUNTIME_UID ${UID:-1000}
 ENV HOME /home/user
 
-RUN adduser -D user -u ${RUNTIME_UID} \
+RUN adduser -D user -u ${RUNTIME_UID} -h $HOME \
 	&& chown -R user $HOME
 
 WORKDIR $HOME


### PR DESCRIPTION
This PR synchronizes the setup of the `RUNTIME_UID` env/arg and the `HOME` env across all of the weechat images.