### PR TITLE
Fix Hollywood - adding recommended utils directly

### DIFF
--- a/hollywood/Dockerfile
+++ b/hollywood/Dockerfile
@@ -1,16 +1,35 @@
-FROM ubuntu:16.04
+# Run Hollywood in a container
+#
+#  docker run --rm -it \
+#    --name hollywood \
+#    jess/hollywood
+#
+# To easily exit, use "F6" which will disconnect from the Byobu
+# session and exit the container.
+#
+FROM debian:bullseye-slim
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y \
 	software-properties-common \
 	--no-install-recommends && \
-	add-apt-repository ppa:hollywood/ppa && \
 	apt-get update && \
 	apt-get install -y \
 	byobu \
 	hollywood \
-	locate \
 	mlocate \
+	tree \
+	apg \
+	bmon \
+	bsdmainutils \
+	ccze \
+	cmatrix \
+	htop \
+	jp2a \
+	moreutils \
+	speedometer \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& updatedb


### PR DESCRIPTION
Without the recommended utils, Hollywood doesn't show anything and stays
empty.
While at it, add a description on how to run (and easily exit) and
update image to Debian Bullseye.