### PR TITLE
Update gcalcli image to python3

### DIFF
--- a/gcalcli/Dockerfile
+++ b/gcalcli/Dockerfile
@@ -4,13 +4,12 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 ENV HOME /home/gcalcli
 
 RUN apk --no-cache add \
-	python \
-	python-dev \
-	py2-pip \
+	python3 \
+	python3-dev \
 	build-base \
 	&& adduser -S gcalcli \
 	&& chown -R gcalcli $HOME \
-	&& pip install vobject parsedatetime gcalcli
+	&& pip3 install vobject parsedatetime gcalcli
 
 WORKDIR $HOME
 USER gcalcli


### PR DESCRIPTION
The latest gcalcli uses shutil.get_terminal_size which isn't backported to python2's shutil.

This PR uses python3 instead of python2.

Error received with the current image:
```
% docker run --rm -t \
     -v /etc/localtime:/etc/localtime:ro \
     -v /tmp/gcalcli_oauth:/home/gcalcli/.gcalcli_oauth \
     -u $(uid -u):$(uid -g) \
     -v /tmp/gcalclirc:/home/gcalcli/.gcalclirc \
     --name gcalcli jess/gcalcli \
         --nocolor \
         --lineart ascii \
         --nocache \
         calw 2019-09-30 3 \
         --width 15 \
         --monday                                                                   
Traceback (most recent call last):                                                                               
  File "/usr/bin/gcalcli", line 7, in <module>                                                                   
    from gcalcli.cli import main                                                                                 
  File "/usr/lib/python2.7/site-packages/gcalcli/cli.py", line 30, in <module>                                   
    from gcalcli.argparsers import get_argument_parser, handle_unparsed                                          
  File "/usr/lib/python2.7/site-packages/gcalcli/argparsers.py", line 8, in <module>                             
    from shutil import get_terminal_size                                                                         
ImportError: cannot import name get_terminal_size
````