### PR TITLE
replacing deprecated 'MAINTAINER' instruction in favor of the recomme…

### DIFF
--- a/bcc-tools/Dockerfile
+++ b/bcc-tools/Dockerfile
@@ -7,7 +7,7 @@
 #	r.j3ss.co/bcc-tools
 #
 FROM debian:sid-slim
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /usr/share/bcc/tools:$PATH
 

--- a/bpftrace/Dockerfile
+++ b/bpftrace/Dockerfile
@@ -1,5 +1,5 @@
 FROM r.j3ss.co/bcc
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /usr/share/bcc/tools:$PATH
 

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12 as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/fleet/Dockerfile
+++ b/fleet/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine AS builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/github-dev/Dockerfile
+++ b/github-dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	bash \

--- a/k8scan/Dockerfile
+++ b/k8scan/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12-alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/nomad/Dockerfile
+++ b/nomad/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.11 as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/now/Dockerfile
+++ b/now/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 RUN	apk add --no-cache \
 	ca-certificates \

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/runc-rootless/Dockerfile
+++ b/runc-rootless/Dockerfile
@@ -15,7 +15,7 @@ RUN git clone https://github.com/jessfraz/runc.git "$GOPATH/src/github.com/openc
 	&& mv runc /usr/bin/runc
 
 FROM alpine:latest
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 RUN apk add --no-cache \
 	bash \
 	shadow \

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-LABEL maintainer="Jessica Frazelle <jess@linux.com>"
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/viewdocs/Dockerfile
+++ b/viewdocs/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go


### PR DESCRIPTION
Replaces deprecated 'MAINTAINER' instruction in favor of the recommendation, 'LABEL'. To ensure they're all now in line I ran `hadolint` against the repo to ensure `DL4000` was no longer present, then checked over  all Dockerfile's for consistency.

References:
 - https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
 - https://github.com/hadolint/hadolint/wiki/DL4000