### PR TITLE
Fix Broken WireGuard

### DIFF
--- a/wireguard/install/Dockerfile
+++ b/wireguard/install/Dockerfile
@@ -8,29 +8,34 @@
 # 	-v /usr/src:/usr/src:ro \
 # 	r.j3ss.co/wireguard:install
 #
-FROM alpine:latest
+FROM debian:sid-slim
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
-RUN apk add --no-cache \
-	build-base \
+RUN apt update && apt -y install \
+	build-essential \
 	ca-certificates \
-	elfutils-libelf \
-	libmnl-dev
+	git \
+	kmod \
+	libelf-dev \
+	libmnl-dev \
+	pkg-config \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 
-# https://git.zx2c4.com/WireGuard/refs/
-ENV WIREGUARD_VERSION 0.0.20191205
+# https://git.zx2c4.com/wireguard-linux-compat/
+ENV WIREGUARD_VERSION v0.0.20200128
+# https://git.zx2c4.com/wireguard-tools
+ENV WIREGUARD_TOOLS_VERSION v1.0.20200121
 
 RUN set -x \
-	&& apk add --no-cache --virtual .build-deps \
-		git \
-	&& git clone --depth 1 --branch "${WIREGUARD_VERSION}" https://git.zx2c4.com/WireGuard.git /wireguard \
+	&& git clone --depth 1 --branch "${WIREGUARD_VERSION}" https://git.zx2c4.com/wireguard-linux-compat.git /wireguard \
+	&& git clone --depth 1 --branch "${WIREGUARD_TOOLS_VERSION}" https://git.zx2c4.com/wireguard-tools.git /wireguard-tools \
 	&& ( \
-		cd /wireguard/src \
-		&& make tools \
-		&& make -C tools install \
-		&& make -C tools clean \
-	) \
-	&& apk del .build-deps
+		cd /wireguard-tools/src \
+		&& make -j$(nproc) \
+		&& make install \
+		&& make clean \
+	)
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/wireguard/tools/Dockerfile
+++ b/wireguard/tools/Dockerfile
@@ -1,10 +1,12 @@
-FROM alpine:latest
+FROM debian:sid-slim
 
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
-RUN apk add --no-cache \
+RUN apt update && apt -y install \
 	ca-certificates \
-	libmnl
+	libmnl-dev \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=r.j3ss.co/wireguard:install /usr/bin/wg /usr/bin/wg
 COPY --from=r.j3ss.co/wireguard:install /usr/share/man/man8/wg.8 /usr/share/man/man8/wg.8


### PR DESCRIPTION
Hey :)

The [WireGuard Git](https://git.zx2c4.com) has changed its structure, so I've changed the Dockerfile accordingly: It now uses `wireguard-compat` (*WireGuard kernel module backport for Linux 3.10 - 5.5*) and `wireguard-tools`.

Also, I've changed the base image to `debian:sid-slim` which also fixes the issue mentioned in #403. 

And I've updated the wireguard tag to a newer version.