### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/atom/Dockerfile
+++ b/atom/Dockerfile
@@ -31,7 +31,9 @@ RUN apt-get update && apt-get install -y \
 	ca-certificates \
 	gnupg \
 	wget \
-	--no-install-recommends
+	--no-install-recommends \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add the atom debian repo
 RUN wget -qO- https://packagecloud.io/AtomEditor/atom/gpgkey | apt-key add -
@@ -56,7 +58,8 @@ RUN apt-get update && apt-get install -y \
 	libx11-xcb-dev \
 	xdg-utils \
 	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Autorun atom
 ENTRYPOINT [ "atom", "--foreground" ]

--- a/atom/Dockerfile
+++ b/atom/Dockerfile
@@ -31,9 +31,7 @@ RUN apt-get update && apt-get install -y \
 	ca-certificates \
 	gnupg \
 	wget \
-	--no-install-recommends \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	--no-install-recommends
 
 # Add the atom debian repo
 RUN wget -qO- https://packagecloud.io/AtomEditor/atom/gpgkey | apt-key add -
@@ -57,7 +55,7 @@ RUN apt-get update && apt-get install -y \
 	libxtst6 \
 	libx11-xcb-dev \
 	xdg-utils \
-	--no-install-recommends \
+	--no-install-recommends && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/cura/Dockerfile
+++ b/cura/Dockerfile
@@ -5,14 +5,12 @@ RUN apt-get update && apt-get install -y \
 	libgfortran4 \
 	libssl-dev \
 	wget \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	--no-install-recommends
 
 RUN wget https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot/uploads/0676b39295476b93181fa8a512f34265/cura-lulzbot_3.2.21_amd64.deb -O /tmp/cura.deb \
-	&& apt update \
 	&& dpkg -i /tmp/cura.deb || true \
 	&& apt-get -yf install \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf /tmp/cura.deb
+	&& apt-get clean \
+    	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["cura-lulzbot"]

--- a/gimp/Dockerfile
+++ b/gimp/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	gimp \
-	--no-install-recommends \
+	--no-install-recommends && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/gimp/Dockerfile
+++ b/gimp/Dockerfile
@@ -14,6 +14,7 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 RUN apt-get update && apt-get install -y \
 	gimp \
 	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT [ "gimp" ]

--- a/lynx/Dockerfile
+++ b/lynx/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	lynx \
-	--no-install-recommends \
+	--no-install-recommends && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/lynx/Dockerfile
+++ b/lynx/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 RUN apt-get update && apt-get install -y \
 	lynx \
 	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT [ "lynx" ]

--- a/nmap/Dockerfile
+++ b/nmap/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
 	nmap \
-	--no-install-recommends \
+	--no-install-recommends && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/nmap/Dockerfile
+++ b/nmap/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 RUN apt-get update && apt-get install -y \
 	nmap \
 	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT [ "nmap" ]

--- a/nomad/Dockerfile
+++ b/nomad/Dockerfile
@@ -8,14 +8,13 @@ RUN apt-get update && apt-get install -y \
 	apt-transport-https \
 	ca-certificates \
 	curl \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
+	--no-install-recommends \
 	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 	&& echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -y \
 	gcc \
 	git \
 	g++ \
@@ -26,8 +25,9 @@ RUN apt-get update && apt-get install -y \
 	python \
 	yarn \
 	zip \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+	--no-install-recommends && \
+	apt-get clean && \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV NOMAD_VERSION v0.10.2
 

--- a/s3cmd/Dockerfile
+++ b/s3cmd/Dockerfile
@@ -13,8 +13,9 @@ LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 RUN apt-get update && apt-get install -y \
 	ca-certificates \
 	s3cmd \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	--no-install-recommends && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Setup s3cmd config
 RUN { \

--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -29,8 +29,9 @@ RUN echo "deb [arch=amd64] https://repo.skype.com/deb stable main" > /etc/apt/so
 
 RUN apt-get update && apt-get -y install \
 	skypeforlinux \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	--no-install-recommends && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY run-skype-and-wait-for-exit /usr/local/bin
 

--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	gnupg \
 	locales \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	--no-install-recommends
 
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
 	&& locale-gen en_US.utf8 \
@@ -37,13 +36,14 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
 RUN curl -sSL https://packagecloud.io/slacktechnologies/slack/gpgkey | apt-key add -
 RUN echo "deb https://packagecloud.io/slacktechnologies/slack/debian/ jessie main" > /etc/apt/sources.list.d/slacktechnologies_slack.list
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get -y install \
 	libasound2 \
 	libgtk-3-0 \
 	libx11-xcb1 \
 	libxkbfile1 \
 	slack-desktop \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	--no-install-recommends && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT ["/usr/lib/slack/slack"]

--- a/slapd/Dockerfile
+++ b/slapd/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && LC_ALL=C DEBIAN_FRONTEND=noninteractive \
 	ldap-utils \
 	slapd \
 	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Just some default values for fun!
 ENV LDAP_ROOTPASS=fsociety LDAP_ORGANIZATION="E CORP" LDAP_DOMAIN=mr.robot.com

--- a/slapd/Dockerfile
+++ b/slapd/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && LC_ALL=C DEBIAN_FRONTEND=noninteractive \
 	apt-get install -y \
 	ldap-utils \
 	slapd \
-	--no-install-recommends \
+	--no-install-recommends && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is 

1.  Slow  because "apt-utils" not installed 

2. to avoid build to exits with error without having certificate in wget , curl etc