### PR TITLE
update image to use python3

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,3 +1,11 @@
+# Run awscli in a container and list s3 buckets
+#
+# docker run --rm -it \
+#	--name awscli \
+#	jess/awscli \
+#       s3 ls
+#
+
 FROM alpine:latest
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
@@ -5,9 +13,8 @@ RUN apk --no-cache add \
 	ca-certificates \
 	groff \
 	less \
-	python \
-	py2-pip \
-	&& pip install awscli \
+	python3 \
+	&& pip3 install awscli \
 	&& mkdir -p /root/.aws \
 	&& { \
 		echo '[default]'; \


### PR DESCRIPTION
python2 has reached end of life, so replacing it with python3.

In addition, pip (python3 version) comes along with the python3 install
on alpine, so no need to install that explicitly.