### PR TITLE
Add sample run; I needed .Xauthority & hostname

### DIFF
--- a/gnuplot/Dockerfile
+++ b/gnuplot/Dockerfile
@@ -1,3 +1,14 @@
+# Run gnuplot in a container
+
+# docker run -d \
+#	-v /tmp/.X11-unix:/tmp/.X11-unix \
+#	-e DISPLAY=unix$DISPLAY \
+#       -v $HOME/.Xauthority:/root/.Xauthority \
+#       --hostname $(hostname) \
+#	--name gnuplot \
+#	jess/gnuplot
+#
+
 FROM alpine:latest
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 


### PR DESCRIPTION
Add comments to get it to run, in my environment anyway (Linux Mint); maybe there is a better way?  I adapted the solution from your 2015 talk on youtube and from https://blog.yadutaf.fr/2017/09/10/running-a-graphical-app-in-a-docker-container-on-a-remote-server/

Would the .Xauthority/hostname fix not be needed if it were not the root user running gnuplot?

Anyway, thanks and best regards, your work is going to support spacecraft navigation.

Brian Carcich