### PR TITLE
Add missing libraries after release of vscode 1.49

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -33,12 +33,15 @@ RUN apt-get update && apt-get -y install \
 	libatk1.0-0 \
 	libcairo2 \
 	libcups2 \
+	libdrm2 \
 	libexpat1 \
 	libfontconfig1 \
 	libfreetype6 \
+	libgbm1 \
 	libgtk2.0-0 \
 	libpango-1.0-0 \
 	libx11-xcb1 \
+	libxcb-dri3-0 \
 	libxcomposite1 \
 	libxcursor1 \
 	libxdamage1 \


### PR DESCRIPTION
Probably related to the [bump to Electron 9.0](https://github.com/Microsoft/vscode-docs/blob/master/release-notes/v1_49.md#electron-90-update).