### PR TITLE
Fix Spotify not running and building

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -14,16 +14,19 @@ FROM debian:sid-slim
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN	apt-get update && apt-get install -y \
+	ca-certificates \
+	curl \
 	dirmngr \
 	gnupg \
 	--no-install-recommends \
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4773BD5E130D1D45 \
+	&& curl -sS https://download.spotify.com/debian/pubkey_0D811D58.gpg | apt-key add -  \
 	&& echo "deb http://repository.spotify.com stable non-free" >> /etc/apt/sources.list.d/spotify.list \
 	&& apt-get update && apt-get install -y \
 	alsa-utils \
 	libgl1-mesa-dri \
 	libgl1-mesa-glx \
 	libpulse0 \
+	libsm6 \
 	spotify-client \
 	xdg-utils \
 	--no-install-recommends \


### PR DESCRIPTION
I could neither run the upstream Docker image nor could I build the Dockerfile.

Bug 1
-----

Cannot run the upstream image:

```
docker pull jess/spotify
docker run -it --rm jess/spotify
spotify: error while loading shared libraries: libSM.so.6: cannot open shared object file: No such file or directory
```

Solution to bug 1
-----------------

Install `libsm6`

Bug 2
-----

Cannot build the Dockerfile:

```
cd dockerfiles/spotify
docker build . --pull
[...]
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
Executing: /tmp/apt-key-gpghome.k3eQma7IzG/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys 4773BD5E130D1D45
gpg: key 4773BD5E130D1D45: public key "Spotify Public Repository Signing Key <tux@spotify.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Hit:1 http://deb.debian.org/debian sid InRelease
Get:2 http://repository.spotify.com stable InRelease [3316 B]
Err:2 http://repository.spotify.com stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D1742AD60D811D58
Reading package lists...
W: GPG error: http://repository.spotify.com stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D1742AD60D811D58
E: The repository 'http://repository.spotify.com stable InRelease' is not signed.
The command '/bin/sh -c apt-get update && apt-get install -y 	dirmngr 	gnupg 	--no-install-recommends 	 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4773BD5E130D1D45 	 echo "deb http://repository.spotify.com stable non-free" >> /etc/apt/sources.list.d/spotify.list 	    && apt-get update && apt-get install -y 	sa-utils 	  libgl1-mesa-dri 	  libgl1-mesa-glx 	  libpulse0 	  spotify-client 	utils 	    --no-install-recommends 	&& rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

Solution to bug 2
-----------------

Replaced instructions to retrieve the key with the official instructions from https://www.spotify.com/us/download/linux/