### PR TITLE
Add fonts to Spotify to support more languages

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -29,6 +29,9 @@ RUN	apt-get update && apt-get install -y \
 	libsm6 \
 	spotify-client \
 	xdg-utils \
+	fonts-noto \
+	fonts-noto-cjk \
+	fonts-noto-color-emoji \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This diff fixes that I can only see squares for Japanese and emojis. The
fonts that I used are the same that are used in the Firefox image.