### PR TITLE
Added missing zoom-us dependencies

### DIFF
--- a/zoom-us/Dockerfile
+++ b/zoom-us/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update && apt-get install -y \
 	libnss3 \
 	libxss1 \
 	sudo \
+	libxcb-xinerama0 \
+	libxkbcommon-x11-0 \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I've tried to build the zoom-us Docker container image and got an error output:
```
dpkg: dependency problems prevent configuration of zoom:
 zoom depends on libxcb-xinerama0; however:
  Package libxcb-xinerama0 is not installed.
 zoom depends on libxkbcommon-x11-0; however:
  Package libxkbcommon-x11-0 is not installed.

dpkg: error processing package zoom (--install):
 dependency problems - leaving unconfigured
Processing triggers for desktop-file-utils (0.26-1) ...
Processing triggers for shared-mime-info (2.0-1) ...
Errors were encountered while processing:
 zoom
```

The error is basically described [in this pull request](https://github.com/jessfraz/dockerfiles/pull/564), which had been untouched for months.

This pull request fixes the installation error(s).