### PR TITLE
Update mpd Dockerfile - add ca-certificates

### DIFF
--- a/mpd/Dockerfile
+++ b/mpd/Dockerfile
@@ -12,6 +12,7 @@ FROM debian:sid-slim
 LABEL maintainer "Jessie Frazelle <jess@linux.com>"
 
 RUN apt-get update && apt-get install -y \
+        ca-certificates \
 	mpc \
 	mpd \
 	nfs-common \


### PR DESCRIPTION
Currently, when Radio streams are played, the mpd client fails with a certificate error.  After `ca-certificates` is manually installed, the radio streams work without issue

FAILED LOGS
```
client: [0] process command "load "Radio-K-Love""
client: [0] command returned 0
client: [0] process command "play"
playlist: play 0:"https://maestro.emfcdn.com/stream_for/k-love/tunein/aac"
client: [0] command returned 0
client: [0] process command "status"
client: [0] command returned 0
client: [0] process command "currentsong"
client: [0] command returned 0
client: [0] process command "readpicture "https://maestro.emfcdn.com/stream_for/k-love/tunein/aac" "0""
exception: CURL failed: server certificate verification failed. CAfile: none CRLfile: none
client: [0] command returned 3
client: [0] process command "albumart "https://maestro.emfcdn.com/stream_for/k-love/tunein/aac" "0""
exception: Failed to decode https://maestro.emfcdn.com/stream_for/k-love/tunein/aac; CURL failed: server certificate verification failed. CAfile: none CRLfile: none
player: played "https://maestro.emfcdn.com/stream_for/k-love/tunein/aac"
exception: CURL failed: server certificate verification failed. CAfile: none CRLfile: none
exception: CURL failed: server certificate verification failed. CAfile: none CRLfile: none
exception: CURL failed: server certificate verification failed. CAfile: none CRLfile: none
```

WORKING LOGS
```
client: [0] process command "load "Radio-K-Love""
client: [0] command returned 0
client: [0] process command "play"
playlist: play 0:"https://maestro.emfcdn.com/stream_for/k-love/tunein/aac"
client: [0] command returned 0
client: [0] process command "status"
client: [0] command returned 0
client: [0] process command "currentsong"
client: [0] command returned 0
client: [0] process command "readpicture "https://maestro.emfcdn.com/stream_for/k-love/tunein/aac" "0""
curl: icy-metaint=100
client: [0] command returned 0
client: [0] process command "albumart "https://maestro.emfcdn.com/stream_for/k-love/tunein/aac" "0""
client: [0] command returned 3
client: [0] process command "idle "database""
client: [0] command returned 1
curl: icy-metaint=100
decoder_thread: probing plugin faad
decoder: audio_format=48000:16:2, seekable=false
output: OutputThread could not get realtime scheduling, continuing anyway: sched_setscheduler failed: Operation not permitted
output: opened "Output1" (pulse) audio_format=48000:24:2
output: converting in=48000:16:2 -> f=48000:24:2 -> out=48000:24:2
client: [0] process command "status"
client: [0] command returned 0
```